### PR TITLE
Update Japan holidays: add bank holidays

### DIFF
--- a/holidays/locale/en_US/LC_MESSAGES/JP.po
+++ b/holidays/locale/en_US/LC_MESSAGES/JP.po
@@ -3,9 +3,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Python Holidays 0.20\n"
-"POT-Creation-Date: 2023-02-15 08:36-0800\n"
-"PO-Revision-Date: 2023-04-06 17:40+0300\n"
+"Project-Id-Version: Python Holidays 0.30\n"
+"POT-Creation-Date: 2023-07-23 15:45+0300\n"
+"PO-Revision-Date: 2023-07-23 15:47+0300\n"
 "Last-Translator: ~Jhellico <jhellico@gmail.com>\n"
 "Language-Team: Python Holidays localization team\n"
 "Language: en_US\n"
@@ -111,3 +111,7 @@ msgstr "Substitute Holiday"
 #. National Holiday.
 msgid "国民の休日"
 msgstr "National Holiday"
+
+#. Bank Holiday.
+msgid "銀行休業日"
+msgstr "Bank Holiday"

--- a/holidays/locale/ja/LC_MESSAGES/JP.po
+++ b/holidays/locale/ja/LC_MESSAGES/JP.po
@@ -3,10 +3,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Python Holidays 0.20\n"
-"POT-Creation-Date: 2023-02-15 08:36-0800\n"
-"PO-Revision-Date: 2023-04-06 17:39+0300\n"
-"Last-Translator: Arkadii Yakovets <ark@cho.red>\n"
+"Project-Id-Version: Python Holidays 0.30\n"
+"POT-Creation-Date: 2023-07-23 15:45+0300\n"
+"PO-Revision-Date: 2023-07-23 15:47+0300\n"
+"Last-Translator: ~Jhellico <jhellico@gmail.com>\n"
 "Language-Team: Python Holidays localization team\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
@@ -110,4 +110,8 @@ msgstr ""
 
 #. National Holiday.
 msgid "国民の休日"
+msgstr ""
+
+#. Bank Holiday.
+msgid "銀行休業日"
 msgstr ""

--- a/tests/countries/test_japan.py
+++ b/tests/countries/test_japan.py
@@ -9,6 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
+from holidays.constants import BANK
 from holidays.countries.japan import Japan, JP, JPN
 from tests.common import TestCase
 
@@ -26,6 +27,10 @@ class TestJapan(TestCase):
             Japan(years=1945)
         with self.assertRaises(NotImplementedError):
             Japan(years=2100)
+        with self.assertRaises(NotImplementedError):
+            Japan(categories=(BANK,), years=1945)
+        with self.assertRaises(NotImplementedError):
+            Japan(categories=(BANK,), years=2100)
 
     def test_new_years_day(self):
         self.assertHoliday(f"{year}-01-01" for year in range(1949, 2051))
@@ -723,9 +728,19 @@ class TestJapan(TestCase):
         self.assertHolidayName(name, dt)
         self.assertNoNonObservedHoliday(dt)
 
+    def test_bank_holidays(self):
+        name = "銀行休業日"
+        holidays = Japan(categories=(BANK,), years=range(1949, 2051))
+        for year in range(1949, 2051):
+            self.assertHolidayName(
+                name, holidays, f"{year}-01-02", f"{year}-01-03", f"{year}-12-31"
+            )
+
     def test_l10n_default(self):
         self.assertLocalizedHolidays(
             ("2022-01-01", "元日"),
+            ("2022-01-02", "銀行休業日"),
+            ("2022-01-03", "銀行休業日"),
             ("2022-01-10", "成人の日"),
             ("2022-02-11", "建国記念の日"),
             ("2022-02-23", "天皇誕生日"),
@@ -741,12 +756,15 @@ class TestJapan(TestCase):
             ("2022-10-10", "スポーツの日"),
             ("2022-11-03", "文化の日"),
             ("2022-11-23", "勤労感謝の日"),
+            ("2022-12-31", "銀行休業日"),
         )
 
     def test_l10n_en_us(self):
         self.assertLocalizedHolidays(
             "en_US",
             ("2022-01-01", "New Year's Day"),
+            ("2022-01-02", "Bank Holiday"),
+            ("2022-01-03", "Bank Holiday"),
             ("2022-01-10", "Coming of Age Day"),
             ("2022-02-11", "Foundation Day"),
             ("2022-02-23", "Emperor's Birthday"),
@@ -762,4 +780,5 @@ class TestJapan(TestCase):
             ("2022-10-10", "Sports Day"),
             ("2022-11-03", "Culture Day"),
             ("2022-11-23", "Labor Thanksgiving Day"),
+            ("2022-12-31", "Bank Holiday"),
         )


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Add Japan bank holidays (Dec 31, Jan 2 and 3).

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] This PR is filed against `beta` branch of the repository
- [x] This PR doesn't contain any merge conflicts and has clean commit history
- [x] The code style looks good: `make pre-commit`
- [x] All tests pass locally: `make test`, `make tox` (we strongly encourage adding tests to your code)
- [x] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/dr-prodigy/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/dr-prodigy/python-holidays/tree/beta/docs/source
