### PR TITLE
chore(python): add Python 3.12 in test matrix

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.8']
 
     steps:
       - uses: actions/checkout@v3
@@ -37,6 +37,7 @@ jobs:
             requirements/runtime.txt
             requirements/tests.txt
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 99
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
 
 [tool.coverage.run]
 branch = true

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ requires =
 env_list =
     docs
     pre-commit
-    python3.{11, 10, 9, 8}
+    python3.{12, 11, 10, 9, 8}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

This PR adds Python 3.12 in CI.

Note: I had to allow pre releases as Python 3.12 is still in beta and will land soon in release candidate.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [ ] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] This PR is filed against `beta` branch of the repository
- [ ] This PR doesn't contain any merge conflicts and has clean commit history
- [ ] The code style looks good: `make pre-commit`
- [ ] All tests pass locally: `make test`, `make tox` (we strongly encourage adding tests to your code)
- [ ] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/dr-prodigy/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/dr-prodigy/python-holidays/tree/beta/docs/source
