### PR TITLE
Tune pre-commit auto-update workflow

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,4 +1,4 @@
-name: Chores
+name: Update pre-commit hooks
 
 on:
   schedule:
@@ -16,13 +16,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4.7.0
+        with:
+          python-version: "3.11"
       - uses: browniebroke/pre-commit-autoupdate-action@v1.0.0
       - uses: peter-evans/create-pull-request@v5.0.2
         with:
-          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           base: beta
-          body: Update versions of pre-commit hooks to the latest version.
-          branch: update/pre-commit-hooks
+          body: Update pre-commit hooks to their latest versions.
+          branch: update-pre-commit-hooks
           commit-message: "Chore: Update pre-commit hooks"
           committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           delete-branch: true


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Tune pre-commit auto-update workflow:
  - Remove author (hope this disables the extra trailer)
  - Set Python version
  - Update name and body


## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've added references to all holidays information sources used in this PR
- [x] This PR is filed against `beta` branch of the repository
- [x] This PR doesn't contain any merge conflicts and has clean commit history
- [x] The code style looks good: `make pre-commit` command generates no changes
- [x] All tests pass locally: `make test`, `make tox` (we strongly encourage adding tests to your code)
- [x] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/beta/docs/source
