### PR TITLE
Remove Columbus Day as state holiday in California

### DIFF
--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -186,6 +186,7 @@ class UnitedStates(ObservedHolidayBase, ChristianHolidays, InternationalHolidays
         if self._year >= 1937 and self.subdiv not in {
             "AK",
             "AR",
+            "CA",
             "DE",
             "FL",
             "HI",

--- a/tests/countries/test_united_states.py
+++ b/tests/countries/test_united_states.py
@@ -447,7 +447,7 @@ class TestUS(TestCase):
         )
         self.assertHolidayName(name, dt)
 
-        subdiv_dont = {"AK", "AR", "DE", "FL", "HI", "NV", "SD", "VI"}
+        subdiv_dont = {"AK", "AR", "CA", "DE", "FL", "HI", "NV", "SD", "VI"}
         for subdiv in set(UnitedStates.subdivisions) - subdiv_dont:
             self.assertHolidayName(name, self.state_hols[subdiv], dt)
 
@@ -470,7 +470,7 @@ class TestUS(TestCase):
             "2023-10-09",
         )
 
-        for subdiv in ("AK", "AR", "DE", "FL", "HI", "NV"):
+        for subdiv in ("AK", "AR", "CA", "DE", "FL", "HI", "NV"):
             self.assertNoHoliday(self.state_hols[subdiv], dt)
             self.assertNoHolidayName(name, self.state_hols[subdiv])
 


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

Columbus day is no longer a state holiday in CA: https://www.sos.ca.gov/state-holidays

## Type of change

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've added references to all holidays information sources used in this PR
- [x] This PR is filed against `beta` branch of the repository
- [x] This PR doesn't contain any merge conflicts and has clean commit history
- [x] The code style looks good: `make pre-commit` command generates no changes
- [x] All tests pass locally: `make test`, `make tox` (we strongly encourage adding tests to your code)
- [x] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/beta/docs/source
