### PR TITLE
Bump mypy version from 1.5.1 to 1.6.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         exclude: ^(docs)
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.6.0
     hooks:
       - id: mypy
         additional_dependencies: [types-all]

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -18,7 +18,7 @@ from calendar import isleap
 from datetime import date, datetime, timedelta, timezone
 from gettext import NullTranslations, gettext, translation
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union, cast
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union, cast
 
 from dateutil.parser import parse
 
@@ -381,7 +381,7 @@ class HolidayBase(Dict[date, str]):
         if not isinstance(key, (date, datetime, float, int, str)):
             raise TypeError(f"Cannot convert type '{type(key)}' to date.")
 
-        return dict.__contains__(cast("Mapping[Any, Any]", self), self.__keytransform__(key))
+        return dict.__contains__(cast("Dict[Any, Any]", self), self.__keytransform__(key))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, HolidayBase):
@@ -391,7 +391,7 @@ class HolidayBase(Dict[date, str]):
             if getattr(self, attribute_name, None) != getattr(other, attribute_name, None):
                 return False
 
-        return dict.__eq__(cast("Mapping[Any, Any]", self), other)
+        return dict.__eq__(cast("Dict[Any, Any]", self), other)
 
     def __getattr__(self, name):
         try:


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Bump mypy version from 1.5.1 to 1.6.0
Change HolidayBase  return type casting from abstract Mapping to more specific Dict (fix mypy operator error).


## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [x] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've added references to all holidays information sources used in this PR
- [x] The code style looks good: `make pre-commit` command generates no changes
- [x] All tests pass locally: `make test`, `make tox` (we strongly encourage adding tests to your code)

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/beta/docs/source
