### PR TITLE
Use setdefault instead of hard-coding observed_rule and observed_since

### DIFF
--- a/holidays/countries/albania.py
+++ b/holidays/countries/albania.py
@@ -36,7 +36,8 @@ class Albania(
         InternationalHolidays.__init__(self)
         IslamicHolidays.__init__(self)
         StaticHolidays.__init__(self, AlbaniaStaticHolidays)
-        super().__init__(observed_rule=SAT_SUN_TO_NEXT_WORKDAY, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_WORKDAY)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/angola.py
+++ b/holidays/countries/angola.py
@@ -50,7 +50,8 @@ class Angola(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, cls=AngolaStaticHolidays)
-        super().__init__(observed_rule=TUE_TO_PREV_MON + THU_TO_NEXT_FRI, *args, **kwargs)
+        kwargs.setdefault("observed_rule", TUE_TO_PREV_MON + THU_TO_NEXT_FRI)
+        super().__init__(*args, **kwargs)
 
     def _is_observed(self, dt: date) -> bool:
         # As per Law # 16/96, from 1996/9/27, when public holiday falls on Sunday,

--- a/holidays/countries/argentina.py
+++ b/holidays/countries/argentina.py
@@ -77,7 +77,8 @@ class Argentina(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, ArgentinaStaticHolidays)
-        super().__init__(observed_rule=TUE_WED_TO_PREV_MON + THU_FRI_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", TUE_WED_TO_PREV_MON + THU_FRI_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -45,7 +45,8 @@ class Australia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, AustraliaStaticHolidays)
-        super().__init__(observed_rule=SAT_SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/azerbaijan.py
+++ b/holidays/countries/azerbaijan.py
@@ -32,9 +32,9 @@ class Azerbaijan(ObservedHolidayBase, InternationalHolidays, IslamicHolidays):
     def __init__(self, *args, **kwargs):
         InternationalHolidays.__init__(self)
         IslamicHolidays.__init__(self, cls=AzerbaijanIslamicHolidays)
-        super().__init__(
-            observed_rule=SAT_SUN_TO_NEXT_WORKDAY, observed_since=2006, *args, **kwargs
-        )
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_WORKDAY)
+        kwargs.setdefault("observed_since", 2006)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         if year <= 1989:

--- a/holidays/countries/barbados.py
+++ b/holidays/countries/barbados.py
@@ -37,7 +37,8 @@ class Barbados(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, St
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, BarbadosStaticHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         # Public Holidays Act Cap.352, 1968-12-30

--- a/holidays/countries/belize.py
+++ b/holidays/countries/belize.py
@@ -37,7 +37,8 @@ class Belize(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         # on a Sunday or a Friday, the following Monday is observed as public
         # holiday; further, if the holiday falls on a Tuesday, Wednesday or
         # Thursday, the preceding Monday is observed as public holiday
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         # Belize was granted independence on 21.09.1981.

--- a/holidays/countries/bolivia.py
+++ b/holidays/countries/bolivia.py
@@ -57,7 +57,9 @@ class Bolivia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         # Supreme Decree #14260.
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, observed_since=1977, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        kwargs.setdefault("observed_since", 1977)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         if year <= 1824:

--- a/holidays/countries/bosnia_and_herzegovina.py
+++ b/holidays/countries/bosnia_and_herzegovina.py
@@ -74,7 +74,8 @@ class BosniaAndHerzegovina(
         ChristianHolidays.__init__(self, JULIAN_CALENDAR)
         InternationalHolidays.__init__(self)
         IslamicHolidays.__init__(self, cls=BosniaAndHerzegovinaIslamicHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/botswana.py
+++ b/holidays/countries/botswana.py
@@ -31,7 +31,9 @@ class Botswana(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, St
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, BotswanaStaticHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, observed_since=1995, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        kwargs.setdefault("observed_since", 1995)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         if year <= 1965:

--- a/holidays/countries/brunei.py
+++ b/holidays/countries/brunei.py
@@ -77,7 +77,8 @@ class Brunei(
         InternationalHolidays.__init__(self)
         IslamicHolidays.__init__(self, cls=BruneiIslamicHolidays)
         StaticHolidays.__init__(self, cls=BruneiStaticHolidays)
-        super().__init__(observed_rule=FRI_SUN_TO_NEXT_SAT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", FRI_SUN_TO_NEXT_SAT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         # Available post-Independence from 1984 afterwards

--- a/holidays/countries/bulgaria.py
+++ b/holidays/countries/bulgaria.py
@@ -52,9 +52,9 @@ class Bulgaria(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self, JULIAN_REVISED_CALENDAR)
         InternationalHolidays.__init__(self)
-        super().__init__(
-            observed_rule=SAT_SUN_TO_NEXT_WORKDAY, observed_since=2017, *args, **kwargs
-        )
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_WORKDAY)
+        kwargs.setdefault("observed_since", 2017)
+        super().__init__(*args, **kwargs)
 
     def _populate_observed(self, dts: Set[date], excluded_names: Set[str]) -> None:
         for dt in sorted(dts):

--- a/holidays/countries/burkina_faso.py
+++ b/holidays/countries/burkina_faso.py
@@ -28,7 +28,8 @@ class BurkinaFaso(ObservedHolidayBase, ChristianHolidays, InternationalHolidays,
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         IslamicHolidays.__init__(self, cls=BurkinaFasoIslamicHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         # On 5 August 1960, Burkina Faso (Republic of Upper Volta at that time)

--- a/holidays/countries/burundi.py
+++ b/holidays/countries/burundi.py
@@ -32,7 +32,8 @@ class Burundi(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Isl
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         IslamicHolidays.__init__(self)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         if year <= 1961:

--- a/holidays/countries/cameroon.py
+++ b/holidays/countries/cameroon.py
@@ -38,7 +38,8 @@ class Cameroon(
         InternationalHolidays.__init__(self)
         IslamicHolidays.__init__(self, cls=CameroonIslamicHolidays)
         StaticHolidays.__init__(self, cls=CameroonStaticHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_WORKDAY, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_WORKDAY)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         # On 1 January 1960, French Cameroun gained independence from France.

--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -65,7 +65,8 @@ class Canada(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, CanadaStaticHolidays)
-        super().__init__(observed_rule=SAT_SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _get_nearest_monday(self, *args) -> date:
         return self._get_observed_date(date(self._year, *args), rule=ALL_TO_NEAREST_MON)

--- a/holidays/countries/chad.py
+++ b/holidays/countries/chad.py
@@ -37,7 +37,8 @@ class Chad(
         InternationalHolidays.__init__(self)
         IslamicHolidays.__init__(self, cls=ChadIslamicHolidays)
         StaticHolidays.__init__(self, ChadStaticHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         # On 11 August 1960, Chad gained independence from France.

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -75,9 +75,9 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, ChileStaticHolidays)
-        super().__init__(
-            observed_rule=WORKDAY_TO_NEAREST_MON, observed_since=2000, *args, **kwargs
-        )
+        kwargs.setdefault("observed_rule", WORKDAY_TO_NEAREST_MON)
+        kwargs.setdefault("observed_since", 2000)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         if year <= 1914:

--- a/holidays/countries/colombia.py
+++ b/holidays/countries/colombia.py
@@ -47,7 +47,9 @@ class Colombia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
-        super().__init__(observed_rule=ALL_TO_NEXT_MON, observed_since=1984, *args, **kwargs)
+        kwargs.setdefault("observed_rule", ALL_TO_NEXT_MON)
+        kwargs.setdefault("observed_since", 1984)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/costa_rica.py
+++ b/holidays/countries/costa_rica.py
@@ -41,7 +41,8 @@ class CostaRica(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
-        super().__init__(observed_rule=ALL_TO_NEAREST_MON_LATAM, *args, **kwargs)
+        kwargs.setdefault("observed_rule", ALL_TO_NEAREST_MON_LATAM)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/cuba.py
+++ b/holidays/countries/cuba.py
@@ -39,7 +39,8 @@ class Cuba(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         # This calendar only works from 1959 onwards.

--- a/holidays/countries/dominican_republic.py
+++ b/holidays/countries/dominican_republic.py
@@ -35,7 +35,8 @@ class DominicanRepublic(ObservedHolidayBase, ChristianHolidays, InternationalHol
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
-        super().__init__(observed_rule=TUE_WED_TO_PREV_MON + THU_FRI_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", TUE_WED_TO_PREV_MON + THU_FRI_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _is_observed(self, dt: date) -> bool:
         # Law No. 139-97 - Holidays Dominican Republic - Jun 27, 1997

--- a/holidays/countries/ecuador.py
+++ b/holidays/countries/ecuador.py
@@ -48,14 +48,12 @@ class Ecuador(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         # When holidays falls on Saturday or Sunday, the rest shall be
         # transferred, respectively, to the preceding Friday or the
         # following Monday.
-        super().__init__(
-            observed_rule=(
-                TUE_TO_PREV_MON + WED_THU_TO_NEXT_FRI + SAT_TO_PREV_FRI + SUN_TO_NEXT_MON
-            ),
-            observed_since=2017,
-            *args,
-            **kwargs,
+        kwargs.setdefault(
+            "observed_rule",
+            TUE_TO_PREV_MON + WED_THU_TO_NEXT_FRI + SAT_TO_PREV_FRI + SUN_TO_NEXT_MON,
         )
+        kwargs.setdefault("observed_since", 2017)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/eswatini.py
+++ b/holidays/countries/eswatini.py
@@ -29,7 +29,9 @@ class Eswatini(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, St
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, cls=EswatiniStaticHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, observed_since=2021, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        kwargs.setdefault("observed_since", 2021)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         # Observed since 1939

--- a/holidays/countries/greece.py
+++ b/holidays/countries/greece.py
@@ -35,7 +35,8 @@ class Greece(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self, JULIAN_REVISED_CALENDAR)
         InternationalHolidays.__init__(self)
-        super().__init__(observed_rule=SAT_SUN_TO_NEXT_WORKDAY, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_WORKDAY)
+        super().__init__(*args, **kwargs)
 
     def _populate_public_holidays(self):
         # New Year's Day.

--- a/holidays/countries/guatemala.py
+++ b/holidays/countries/guatemala.py
@@ -38,7 +38,8 @@ class Guatemala(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
-        super().__init__(observed_rule=ALL_TO_NEAREST_MON_LATAM, *args, **kwargs)
+        kwargs.setdefault("observed_rule", ALL_TO_NEAREST_MON_LATAM)
+        super().__init__(*args, **kwargs)
 
     def _is_observed(self, dt: date) -> bool:
         return dt >= date(2018, OCT, 18)

--- a/holidays/countries/hongkong.py
+++ b/holidays/countries/hongkong.py
@@ -50,7 +50,8 @@ class HongKong(
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, HongKongStaticHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_WORKDAY, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_WORKDAY)
+        super().__init__(*args, **kwargs)
 
     def _add_holiday(self, name: str, *args) -> Optional[date]:
         dt = args if len(args) > 1 else args[0]

--- a/holidays/countries/hungary.py
+++ b/holidays/countries/hungary.py
@@ -35,12 +35,9 @@ class Hungary(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
-        super().__init__(
-            observed_rule=TUE_TO_PREV_MON + THU_TO_NEXT_FRI,
-            observed_since=2010,
-            *args,
-            **kwargs,
-        )
+        kwargs.setdefault("observed_rule", TUE_TO_PREV_MON + THU_TO_NEXT_FRI)
+        kwargs.setdefault("observed_since", 2010)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -32,7 +32,8 @@ class Ireland(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Sta
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, IrelandStaticHolidays)
-        super().__init__(observed_rule=SAT_SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/jamaica.py
+++ b/holidays/countries/jamaica.py
@@ -30,7 +30,8 @@ class Jamaica(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/kazakhstan.py
+++ b/holidays/countries/kazakhstan.py
@@ -29,9 +29,9 @@ class Kazakhstan(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, 
         ChristianHolidays.__init__(self, JULIAN_CALENDAR)
         InternationalHolidays.__init__(self)
         IslamicHolidays.__init__(self)
-        super().__init__(
-            observed_rule=SAT_SUN_TO_NEXT_WORKDAY, observed_since=2002, *args, **kwargs
-        )
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_WORKDAY)
+        kwargs.setdefault("observed_since", 2002)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         # Kazakhstan declared its sovereignty on 25 October 1990

--- a/holidays/countries/kenya.py
+++ b/holidays/countries/kenya.py
@@ -28,7 +28,8 @@ class Kenya(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, cls=KenyaStaticHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         if year <= 1962:

--- a/holidays/countries/laos.py
+++ b/holidays/countries/laos.py
@@ -74,7 +74,9 @@ class Laos(ObservedHolidayBase, InternationalHolidays, StaticHolidays, ThaiCalen
         InternationalHolidays.__init__(self)
         ThaiCalendarHolidays.__init__(self, KHMER_CALENDAR)
         StaticHolidays.__init__(self, cls=LaosStaticHolidays)
-        super().__init__(observed_rule=SAT_SUN_TO_NEXT_MON, observed_since=2018, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
+        kwargs.setdefault("observed_since", 2018)
+        super().__init__(*args, **kwargs)
 
     def _populate_bank_holidays(self):
         # Based on both LSX and BCEL calendar.

--- a/holidays/countries/latvia.py
+++ b/holidays/countries/latvia.py
@@ -34,7 +34,8 @@ class Latvia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, LatviaStaticHolidays)
-        super().__init__(observed_rule=SAT_SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         if year <= 1989:

--- a/holidays/countries/malawi.py
+++ b/holidays/countries/malawi.py
@@ -29,7 +29,8 @@ class Malawi(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
-        super().__init__(observed_rule=SAT_SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         # Observed since 2000

--- a/holidays/countries/malaysia.py
+++ b/holidays/countries/malaysia.py
@@ -133,7 +133,8 @@ class Malaysia(
         InternationalHolidays.__init__(self)
         IslamicHolidays.__init__(self, cls=MalaysiaIslamicHolidays)
         StaticHolidays.__init__(self, cls=MalaysiaStaticHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_WORKDAY, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_WORKDAY)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/marshall_islands.py
+++ b/holidays/countries/marshall_islands.py
@@ -29,7 +29,8 @@ class HolidaysMH(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, 
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, MarshalIslandsStaticHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/monaco.py
+++ b/holidays/countries/monaco.py
@@ -32,7 +32,8 @@ class Monaco(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, MonacoStaticHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/montenegro.py
+++ b/holidays/countries/montenegro.py
@@ -29,7 +29,8 @@ class Montenegro(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self, calendar=JULIAN_CALENDAR)
         InternationalHolidays.__init__(self)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/mozambique.py
+++ b/holidays/countries/mozambique.py
@@ -25,7 +25,8 @@ class Mozambique(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         if year <= 1974:

--- a/holidays/countries/namibia.py
+++ b/holidays/countries/namibia.py
@@ -34,7 +34,9 @@ class Namibia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Sta
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, NamibiaStaticHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, observed_since=1991, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        kwargs.setdefault("observed_since", 1991)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         if year <= 1989:

--- a/holidays/countries/new_zealand.py
+++ b/holidays/countries/new_zealand.py
@@ -71,7 +71,8 @@ class NewZealand(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, 
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, NewZelandStaticHolidays)
-        super().__init__(observed_rule=SAT_SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _get_nearest_monday(self, *args) -> date:
         dt = args if len(args) > 1 else args[0]

--- a/holidays/countries/nigeria.py
+++ b/holidays/countries/nigeria.py
@@ -34,9 +34,9 @@ class Nigeria(
         InternationalHolidays.__init__(self)
         IslamicHolidays.__init__(self)
         StaticHolidays.__init__(self, NigeriaStaticHolidays)
-        super().__init__(
-            observed_rule=SAT_SUN_TO_NEXT_WORKDAY, observed_since=2016, *args, **kwargs
-        )
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_WORKDAY)
+        kwargs.setdefault("observed_since", 2016)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         if year <= 1978:

--- a/holidays/countries/panama.py
+++ b/holidays/countries/panama.py
@@ -26,7 +26,8 @@ class Panama(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/saudi_arabia.py
+++ b/holidays/countries/saudi_arabia.py
@@ -53,7 +53,8 @@ class SaudiArabia(ObservedHolidayBase, IslamicHolidays, StaticHolidays):
     def __init__(self, *args, **kwargs):
         IslamicHolidays.__init__(self)
         StaticHolidays.__init__(self, SaudiArabiaStaticHolidays)
-        super().__init__(observed_rule=FRI_TO_PREV_THU + SAT_TO_NEXT_SUN, *args, **kwargs)
+        kwargs.setdefault("observed_rule", FRI_TO_PREV_THU + SAT_TO_NEXT_SUN)
+        super().__init__(*args, **kwargs)
 
     def _add_islamic_observed(self, dts: Set[date]) -> None:
         # Observed days are added to make up for any days falling on a weekend.

--- a/holidays/countries/serbia.py
+++ b/holidays/countries/serbia.py
@@ -33,7 +33,8 @@ class Serbia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self, JULIAN_CALENDAR)
         InternationalHolidays.__init__(self)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/singapore.py
+++ b/holidays/countries/singapore.py
@@ -86,7 +86,9 @@ class Singapore(
         # "if any day specified in the Schedule falls on a Sunday,
         # the day next following not being itself a public holiday
         # is declared a public holiday in Singapore."
-        super().__init__(observed_rule=SUN_TO_NEXT_WORKDAY, observed_since=1998, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_WORKDAY)
+        kwargs.setdefault("observed_since", 1998)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year) -> None:
         super()._populate(year)

--- a/holidays/countries/south_africa.py
+++ b/holidays/countries/south_africa.py
@@ -27,7 +27,9 @@ class SouthAfrica(ObservedHolidayBase, ChristianHolidays, InternationalHolidays,
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, SouthAfricaStaticHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, observed_since=1995, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        kwargs.setdefault("observed_since", 1995)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         # Observed since 1910, with a few name changes

--- a/holidays/countries/spain.py
+++ b/holidays/countries/spain.py
@@ -68,7 +68,8 @@ class Spain(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Islam
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         IslamicHolidays.__init__(self, cls=SpainIslamicHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/taiwan.py
+++ b/holidays/countries/taiwan.py
@@ -35,12 +35,9 @@ class Taiwan(ObservedHolidayBase, ChineseCalendarHolidays, InternationalHolidays
     def __init__(self, *args, **kwargs):
         ChineseCalendarHolidays.__init__(self)
         InternationalHolidays.__init__(self)
-        super().__init__(
-            observed_rule=SAT_TO_PREV_WORKDAY + SUN_TO_NEXT_WORKDAY,
-            observed_since=2015,
-            *args,
-            **kwargs,
-        )
+        kwargs.setdefault("observed_rule", SAT_TO_PREV_WORKDAY + SUN_TO_NEXT_WORKDAY)
+        kwargs.setdefault("observed_since", 2015)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         if year <= 1911:

--- a/holidays/countries/thailand.py
+++ b/holidays/countries/thailand.py
@@ -146,7 +146,8 @@ class Thailand(ObservedHolidayBase, InternationalHolidays, StaticHolidays, ThaiC
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, ThailandStaticHolidays)
         ThaiCalendarHolidays.__init__(self)
-        super().__init__(observed_rule=SAT_SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _is_observed(self, dt: date) -> bool:
         return 1961 <= self._year <= 1973 or 1995 <= self._year <= 1997 or self._year >= 2001

--- a/holidays/countries/ukraine.py
+++ b/holidays/countries/ukraine.py
@@ -75,7 +75,8 @@ class Ukraine(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Sta
         ChristianHolidays.__init__(self, JULIAN_CALENDAR)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, UkraineStaticHolidays)
-        super().__init__(observed_rule=SAT_SUN_TO_NEXT_WORKDAY, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_WORKDAY)
+        super().__init__(*args, **kwargs)
 
     def _is_observed(self, dt: date) -> bool:
         # 27.01.1995: holiday on weekend move to next workday

--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -50,7 +50,8 @@ class UnitedKingdom(ObservedHolidayBase, ChristianHolidays, InternationalHoliday
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, UnitedKingdomStaticHolidays)
-        super().__init__(observed_rule=SAT_SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year: int) -> None:
         super()._populate(year)

--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -112,7 +112,8 @@ class UnitedStates(ObservedHolidayBase, ChristianHolidays, InternationalHolidays
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
-        super().__init__(observed_rule=SAT_TO_PREV_FRI + SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SAT_TO_PREV_FRI + SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/uruguay.py
+++ b/holidays/countries/uruguay.py
@@ -45,7 +45,8 @@ class Uruguay(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Sta
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, cls=UruguayStaticHolidays)
         # Decree Law #14977, # 15535, #16805.
-        super().__init__(observed_rule=TUE_WED_TO_PREV_MON + THU_FRI_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", TUE_WED_TO_PREV_MON + THU_FRI_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _is_observed(self, dt: date) -> bool:
         return 1980 <= self._year <= 1983 or self._year >= 1997

--- a/holidays/countries/vanuatu.py
+++ b/holidays/countries/vanuatu.py
@@ -28,7 +28,8 @@ class Vanuatu(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Sta
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, VanatuStaticHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         # On 30 July 1980, Vanuatu gained independence from Britain and France.

--- a/holidays/countries/vietnam.py
+++ b/holidays/countries/vietnam.py
@@ -26,7 +26,8 @@ class Vietnam(ObservedHolidayBase, ChineseCalendarHolidays, InternationalHoliday
     def __init__(self, *args, **kwargs):
         ChineseCalendarHolidays.__init__(self)
         InternationalHolidays.__init__(self)
-        super().__init__(observed_rule=SAT_SUN_TO_NEXT_WORKDAY, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_WORKDAY)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         super()._populate(year)

--- a/holidays/countries/zambia.py
+++ b/holidays/countries/zambia.py
@@ -29,7 +29,8 @@ class Zambia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
         StaticHolidays.__init__(self, ZambiaStaticHolidays)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         # Observed since 1965

--- a/holidays/countries/zimbabwe.py
+++ b/holidays/countries/zimbabwe.py
@@ -25,7 +25,8 @@ class Zimbabwe(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self)
         InternationalHolidays.__init__(self)
-        super().__init__(observed_rule=SUN_TO_NEXT_MON, *args, **kwargs)
+        kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
+        super().__init__(*args, **kwargs)
 
     def _populate(self, year):
         if year <= 1987:


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Instead of calling super().init() from countries with hard-coded values for override_rule and override_since, use kwargs.setdefaults() to add a value if one isn't passed in. This allows for users to set their own override_rule and override_since if desired.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've added references to all holidays information sources used in this PR
- [x] The code style looks good: `make pre-commit` command generates no changes
- [x] All tests pass locally: `make test`, `make tox` (we strongly encourage adding tests to your code)

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/beta/docs/source
