### PR TITLE
Add `_next_year_new_years_day` to InternationalHolidays

### DIFF
--- a/holidays/countries/angola.py
+++ b/holidays/countries/angola.py
@@ -13,7 +13,7 @@ from datetime import date
 from gettext import gettext as tr
 from typing import Tuple
 
-from holidays.calendars.gregorian import AUG, SEP, DEC
+from holidays.calendars.gregorian import AUG, SEP
 from holidays.groups import ChristianHolidays, InternationalHolidays, StaticHolidays
 from holidays.observed_holiday_base import (
     ObservedHolidayBase,
@@ -58,12 +58,13 @@ class Angola(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         # it rolls over to the following Monday.
         return dt >= date(1996, SEP, 27)
 
-    def _add_observed(self, dt: date, *args) -> Tuple[bool, date]:
+    def _add_observed(self, dt: date, **kwargs) -> Tuple[bool, date]:
         # As per Law # #11/18, from 2018/9/10, when public holiday falls on Tuesday or Thursday,
         # the Monday or Friday is also a holiday.
-        return super()._add_observed(
-            dt, rule=SUN_TO_NEXT_MON if dt < date(2018, SEP, 10) else self._observed_rule
+        kwargs.setdefault(
+            "rule", SUN_TO_NEXT_MON if dt < date(2018, SEP, 10) else self._observed_rule
         )
+        return super()._add_observed(dt, **kwargs)
 
     def _populate(self, year):
         # Decree #5/75.
@@ -75,11 +76,9 @@ class Angola(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         # New Year's Day.
         name = self.tr("Dia do Ano Novo")
         dt = self._add_new_years_day(name)
-        if year <= 2011 or year >= 2019:
+        if year <= 2011 or year >= 2018:
             self._add_observed(dt)
-
-        if self.observed and self._is_monday(DEC, 31) and year >= 2018:
-            self._add_holiday_dec_31(self.tr(self.observed_label) % name)
+            self._add_observed(self._next_year_new_years_day, name=name)
 
         # Law #16/96.
         if 1997 <= year <= 2011:

--- a/holidays/countries/ecuador.py
+++ b/holidays/countries/ecuador.py
@@ -11,7 +11,6 @@
 
 from gettext import gettext as tr
 
-from holidays.calendars.gregorian import DEC
 from holidays.groups import ChristianHolidays, InternationalHolidays
 from holidays.observed_holiday_base import (
     ObservedHolidayBase,
@@ -61,9 +60,7 @@ class Ecuador(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         # New Year's Day.
         name = self.tr("Año Nuevo")
         self._add_observed(self._add_new_years_day(name), rule=SAT_TO_PREV_FRI + SUN_TO_NEXT_MON)
-
-        if self.observed and self._is_friday(DEC, 31) and year >= 2017:
-            self._add_holiday_dec_31(self.tr(self.observed_label) % name)
+        self._add_observed(self._next_year_new_years_day, name=name, rule=SAT_TO_PREV_FRI)
 
         # Carnival.
         name = tr("Carnaval")

--- a/holidays/countries/hungary.py
+++ b/holidays/countries/hungary.py
@@ -11,7 +11,6 @@
 
 from gettext import gettext as tr
 
-from holidays.calendars.gregorian import DEC
 from holidays.groups import ChristianHolidays, InternationalHolidays
 from holidays.observed_holiday_base import ObservedHolidayBase, TUE_TO_PREV_MON, THU_TO_NEXT_FRI
 
@@ -47,11 +46,7 @@ class Hungary(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         jan_1 = self._add_new_years_day(name)
         if year >= 2014:
             self._add_observed(jan_1)
-
-            # The last day of the year is an observed day off if New Year's Day
-            # falls on a Tuesday.
-            if self.observed and self._is_monday(DEC, 31):
-                self._add_holiday_dec_31(self.tr(self.observed_label_before) % name)
+            self._add_observed(self._next_year_new_years_day, name=name)
 
         if 1945 <= year <= 1950 or year >= 1989:
             # National Day.

--- a/holidays/countries/taiwan.py
+++ b/holidays/countries/taiwan.py
@@ -9,7 +9,6 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from holidays.calendars.gregorian import DEC
 from holidays.groups import ChineseCalendarHolidays, InternationalHolidays
 from holidays.observed_holiday_base import (
     ObservedHolidayBase,
@@ -49,9 +48,7 @@ class Taiwan(ObservedHolidayBase, ChineseCalendarHolidays, InternationalHolidays
         # Republic of China Founding Day / New Year's Day.
         name = "Republic of China Founding Day / New Year's Day"
         dts_observed.add(self._add_new_years_day(name))
-
-        if self.observed and self._is_friday(DEC, 31) and year >= 2015:
-            self._add_holiday_dec_31(self.observed_label % name)
+        self._add_observed(self._next_year_new_years_day, name=name)
 
         # Lunar New Year.
         self._add_chinese_new_years_eve("Lunar New Year's Eve")

--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -122,10 +122,7 @@ class UnitedStates(ObservedHolidayBase, ChristianHolidays, InternationalHolidays
         if year >= 1871:
             name = "New Year's Day"
             self._add_observed(self._add_new_years_day(name))
-            # The following year's observed New Year's Day can be in this year
-            # when it falls on a Friday (Jan 1st is a Saturday).
-            if self.observed and self._is_friday(DEC, 31):
-                self._add_holiday_dec_31(self.observed_label % name)
+            self._add_observed(self._next_year_new_years_day, name=name)
 
         # Memorial Day
         if year >= 1888:

--- a/holidays/groups/international.py
+++ b/holidays/groups/international.py
@@ -11,11 +11,20 @@
 
 from datetime import date
 
+from holidays.calendars.gregorian import JAN
+
 
 class InternationalHolidays:
     """
     International holidays.
     """
+
+    @property
+    def _next_year_new_years_day(self):
+        """
+        Return New Year's Day of next year.
+        """
+        return date(self._year + 1, JAN, 1)
 
     def _add_africa_day(self, name):
         """


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Add `_next_year_new_years_day` property to `InternationalHolidays` class. This simplifies observed New Year's Day calculation in countries where observing rules allow for holiday to be moved to **previous** day.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've added references to all holidays information sources used in this PR
- [x] The code style looks good: `make pre-commit` command generates no changes
- [x] All tests pass locally: `make test`, `make tox` (we strongly encourage adding tests to your code)

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/beta/docs/source
