### PR TITLE
Add supported categories validation

### DIFF
--- a/holidays/constants.py
+++ b/holidays/constants.py
@@ -51,19 +51,3 @@ CHRISTIAN = "christian"
 HEBREW = "hebrew"
 HINDU = "hindu"
 ISLAMIC = "islamic"
-
-ALL_CATEGORIES = {
-    ARMED_FORCES,
-    BANK,
-    CHINESE,
-    CHRISTIAN,
-    GOVERNMENT,
-    HALF_DAY,
-    HEBREW,
-    HINDU,
-    ISLAMIC,
-    OPTIONAL,
-    PUBLIC,
-    SCHOOL,
-    WORKDAY,
-}

--- a/holidays/countries/austria.py
+++ b/holidays/countries/austria.py
@@ -19,7 +19,7 @@ from holidays.holiday_base import HolidayBase
 class Austria(HolidayBase, ChristianHolidays, InternationalHolidays):
     country = "AT"
     default_language = "de"
-    supported_categories = {BANK, PUBLIC}
+    supported_categories = (BANK, PUBLIC)
     supported_languages = ("de", "en_US", "uk")
     subdivisions = ("1", "2", "3", "4", "5", "6", "7", "8", "9")
 

--- a/holidays/countries/belgium.py
+++ b/holidays/countries/belgium.py
@@ -27,7 +27,7 @@ class Belgium(HolidayBase, ChristianHolidays, InternationalHolidays):
 
     country = "BE"
     default_language = "nl"
-    supported_categories = {BANK, PUBLIC}
+    supported_categories = (BANK, PUBLIC)
     supported_languages = ("de", "en_US", "fr", "nl", "uk")
 
     def __init__(self, *args, **kwargs):

--- a/holidays/countries/brazil.py
+++ b/holidays/countries/brazil.py
@@ -56,7 +56,7 @@ class Brazil(HolidayBase, ChristianHolidays, InternationalHolidays):
         "SP",  # São Paulo
         "TO",  # Tocantins
     )
-    supported_categories = {OPTIONAL, PUBLIC}
+    supported_categories = (OPTIONAL, PUBLIC)
 
     def __init__(self, *args, **kwargs) -> None:
         ChristianHolidays.__init__(self)

--- a/holidays/countries/bulgaria.py
+++ b/holidays/countries/bulgaria.py
@@ -46,7 +46,7 @@ class Bulgaria(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     default_language = "bg"
     # %s (Observed).
     observed_label = tr("%s (почивен ден)")
-    supported_categories = {PUBLIC, SCHOOL}
+    supported_categories = (PUBLIC, SCHOOL)
     supported_languages = ("bg", "en_US", "uk")
 
     def __init__(self, *args, **kwargs):

--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -43,7 +43,7 @@ class Canada(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
     default_language = "en"
     # %s (Observed).
     observed_label = tr("%s (Observed)")
-    supported_categories = {GOVERNMENT, OPTIONAL, PUBLIC}
+    supported_categories = (GOVERNMENT, OPTIONAL, PUBLIC)
     subdivisions = (
         "AB",
         "BC",

--- a/holidays/countries/china.py
+++ b/holidays/countries/china.py
@@ -61,7 +61,7 @@ class China(HolidayBase, ChineseCalendarHolidays, InternationalHolidays, StaticH
     """
 
     country = "CN"
-    supported_categories = {PUBLIC, HALF_DAY}
+    supported_categories = (PUBLIC, HALF_DAY)
     default_language = "zh_CN"
     supported_languages = ("en_US", "th", "zh_CN", "zh_TW")
 

--- a/holidays/countries/denmark.py
+++ b/holidays/countries/denmark.py
@@ -29,7 +29,7 @@ class Denmark(HolidayBase, ChristianHolidays, InternationalHolidays):
 
     country = "DK"
     default_language = "da"
-    supported_categories = {OPTIONAL, PUBLIC}
+    supported_categories = (OPTIONAL, PUBLIC)
     supported_languages = ("da", "en_US", "uk")
 
     def __init__(self, *args, **kwargs):

--- a/holidays/countries/greece.py
+++ b/holidays/countries/greece.py
@@ -29,7 +29,7 @@ class Greece(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     default_language = "el"
     # %s (Observed).
     observed_label = tr("%s (παρατηρήθηκε)")
-    supported_categories = {HALF_DAY, PUBLIC}
+    supported_categories = (HALF_DAY, PUBLIC)
     supported_languages = ("el", "en_US", "uk")
 
     def __init__(self, *args, **kwargs):

--- a/holidays/countries/indonesia.py
+++ b/holidays/countries/indonesia.py
@@ -50,7 +50,7 @@ class Indonesia(
     default_language = "id"
     estimated_label = tr("%s* (*perkiraan)")
     supported_languages = ("en_US", "id", "uk")
-    supported_categories = {GOVERNMENT, PUBLIC}
+    supported_categories = (GOVERNMENT, PUBLIC)
 
     def __init__(self, *args, **kwargs):
         BuddhistCalendarHolidays.__init__(self, cls=IndonesiaBuddhistHolidays, show_estimated=True)

--- a/holidays/countries/israel.py
+++ b/holidays/countries/israel.py
@@ -28,7 +28,7 @@ from holidays.observed_holiday_base import (
 class Israel(ObservedHolidayBase):
     country = "IL"
     observed_label = "%s (Observed)"
-    supported_categories = {OPTIONAL, PUBLIC, SCHOOL}
+    supported_categories = (OPTIONAL, PUBLIC, SCHOOL)
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("observed_rule", FRI_TO_PREV_THU + SAT_TO_PREV_THU)

--- a/holidays/countries/japan.py
+++ b/holidays/countries/japan.py
@@ -31,7 +31,7 @@ class Japan(HolidayBase, InternationalHolidays, StaticHolidays):
 
     country = "JP"
     default_language = "ja"
-    supported_categories = {BANK, PUBLIC}
+    supported_categories = (BANK, PUBLIC)
     supported_languages = ("en_US", "ja", "th")
 
     def __init__(self, *args, **kwargs) -> None:

--- a/holidays/countries/laos.py
+++ b/holidays/countries/laos.py
@@ -64,7 +64,7 @@ class Laos(ObservedHolidayBase, InternationalHolidays, StaticHolidays, ThaiCalen
     """
 
     country = "LA"
-    supported_categories = {BANK, PUBLIC, SCHOOL, WORKDAY}
+    supported_categories = (BANK, PUBLIC, SCHOOL, WORKDAY)
     default_language = "lo"
     # %s (in lieu).
     observed_label = tr("ພັກຊົດເຊີຍ%s")

--- a/holidays/countries/liechtenstein.py
+++ b/holidays/countries/liechtenstein.py
@@ -27,7 +27,7 @@ class Liechtenstein(HolidayBase, ChristianHolidays, InternationalHolidays):
 
     country = "LI"
     default_language = "de"
-    supported_categories = {BANK, PUBLIC}
+    supported_categories = (BANK, PUBLIC)
     supported_languages = ("de", "en_US", "uk")
 
     def __init__(self, *args, **kwargs) -> None:

--- a/holidays/countries/netherlands.py
+++ b/holidays/countries/netherlands.py
@@ -30,7 +30,7 @@ class Netherlands(HolidayBase, ChristianHolidays, InternationalHolidays):
 
     country = "NL"
     default_language = "nl"
-    supported_categories = {OPTIONAL, PUBLIC}
+    supported_categories = (OPTIONAL, PUBLIC)
     supported_languages = ("en_US", "nl", "uk")
 
     def __init__(self, *args, **kwargs):

--- a/holidays/countries/portugal.py
+++ b/holidays/countries/portugal.py
@@ -38,7 +38,7 @@ class Portugal(HolidayBase, ChristianHolidays, InternationalHolidays):
 
     country = "PT"
     default_language = "pt_PT"
-    supported_categories = {OPTIONAL, PUBLIC}
+    supported_categories = (OPTIONAL, PUBLIC)
 
     # https://en.wikipedia.org/wiki/ISO_3166-2:PT
     subdivisions = (

--- a/holidays/countries/slovakia.py
+++ b/holidays/countries/slovakia.py
@@ -26,7 +26,7 @@ class Slovakia(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHoli
 
     country = "SK"
     default_language = "sk"
-    supported_categories = {PUBLIC, WORKDAY}
+    supported_categories = (PUBLIC, WORKDAY)
     supported_languages = ("en_US", "sk", "uk")
 
     def __init__(self, *args, **kwargs):

--- a/holidays/countries/south_korea.py
+++ b/holidays/countries/south_korea.py
@@ -74,7 +74,7 @@ class SouthKorea(
     """
 
     country = "KR"
-    supported_categories = {BANK, PUBLIC}
+    supported_categories = (BANK, PUBLIC)
     default_language = "ko"
     # Alternative holiday for %s.
     observed_label = tr("%s 대체 휴일")

--- a/holidays/countries/tanzania.py
+++ b/holidays/countries/tanzania.py
@@ -58,7 +58,7 @@ class Tanzania(
     """
 
     country = "TZ"
-    supported_categories = {BANK, PUBLIC}
+    supported_categories = (BANK, PUBLIC)
     default_language = "sw"
     estimated_label = tr("%s* (*makisio)")
     supported_languages = ("en_US", "sw")

--- a/holidays/countries/thailand.py
+++ b/holidays/countries/thailand.py
@@ -133,7 +133,7 @@ class Thailand(ObservedHolidayBase, InternationalHolidays, StaticHolidays, ThaiC
     """
 
     country = "TH"
-    supported_categories = {ARMED_FORCES, BANK, GOVERNMENT, PUBLIC, SCHOOL, WORKDAY}
+    supported_categories = (ARMED_FORCES, BANK, GOVERNMENT, PUBLIC, SCHOOL, WORKDAY)
     default_language = "th"
     # %s (in lieu).
     observed_label = tr("ชดเชย%s")

--- a/holidays/countries/timor_leste.py
+++ b/holidays/countries/timor_leste.py
@@ -41,7 +41,7 @@ class TimorLeste(
     """
 
     country = "TL"
-    supported_categories = {GOVERNMENT, PUBLIC, WORKDAY}
+    supported_categories = (GOVERNMENT, PUBLIC, WORKDAY)
     default_language = "pt_TL"
     estimated_label = tr("%s* (*aproximada)")
     supported_languages = ("en_US", "pt_TL", "tet")

--- a/holidays/countries/turkey.py
+++ b/holidays/countries/turkey.py
@@ -32,7 +32,7 @@ class Turkey(HolidayBase, InternationalHolidays, IslamicHolidays, StaticHolidays
     default_language = "tr"
     # Estimated label.
     estimated_label = tr("%s* (*tahmini)")
-    supported_categories = {HALF_DAY, PUBLIC}
+    supported_categories = (HALF_DAY, PUBLIC)
     supported_languages = ("en_US", "tr", "uk")
 
     def __init__(self, *args, **kwargs):

--- a/holidays/countries/uruguay.py
+++ b/holidays/countries/uruguay.py
@@ -37,7 +37,7 @@ class Uruguay(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Sta
 
     country = "UY"
     default_language = "es"
-    supported_categories = {BANK, PUBLIC}
+    supported_categories = (BANK, PUBLIC)
     supported_languages = ("en_US", "es", "uk")
 
     def __init__(self, *args, **kwargs):

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -34,7 +34,7 @@ from holidays.calendars.gregorian import (
     _get_nth_weekday_from,
     _get_nth_weekday_of_month,
 )
-from holidays.constants import HOLIDAY_NAME_DELIMITER, ALL_CATEGORIES, PUBLIC
+from holidays.constants import HOLIDAY_NAME_DELIMITER, PUBLIC
 from holidays.helpers import _normalize_arguments, _normalize_tuple
 
 CategoryArg = Union[str, Iterable[str]]
@@ -231,7 +231,7 @@ class HolidayBase(Dict[date, str]):
     """The entity language used by default."""
     categories: Optional[Set[str]] = None
     """Requested holiday categories."""
-    supported_categories: Set[str] = set()
+    supported_categories: Tuple[str, ...] = ()
     """All holiday categories supported by this entity."""
     supported_languages: Tuple[str, ...] = ()
     """All languages supported by this entity."""
@@ -319,10 +319,11 @@ class HolidayBase(Dict[date, str]):
                     DeprecationWarning,
                 )
 
-            unknown_categories = self.categories.difference(  # type: ignore[union-attr]
-                ALL_CATEGORIES
-            )
-            if len(unknown_categories) > 0:
+            if len(self.supported_categories) > 0 and (
+                unknown_categories := self.categories.difference(  # type: ignore[union-attr]
+                    set(self.supported_categories)
+                )
+            ):
                 raise NotImplementedError(
                     f"Category is not supported: {', '.join(unknown_categories)}."
                 )

--- a/tests/test_holiday_base.py
+++ b/tests/test_holiday_base.py
@@ -15,7 +15,7 @@ from datetime import date, datetime
 from datetime import timedelta as td
 
 from holidays.calendars.gregorian import JAN, FEB, OCT, DEC, MON, TUE, SAT, SUN
-from holidays.constants import HOLIDAY_NAME_DELIMITER, PUBLIC
+from holidays.constants import HOLIDAY_NAME_DELIMITER, OPTIONAL, PUBLIC, SCHOOL
 from holidays.holiday_base import HolidayBase
 
 
@@ -35,7 +35,6 @@ class EntityStub(HolidayBase):
     }
     substituted_date_format = "%d/%m/%Y"
     substituted_label = "From %s"
-    supported_categories = {PUBLIC}
 
     def _add_observed(self, dt: date, before: bool = True, after: bool = True) -> None:
         if not self.observed:
@@ -63,6 +62,7 @@ class EntityStub(HolidayBase):
 class CountryStub1(EntityStub):
     country = "CS1"
     subdivisions = ("Subdiv1", "Subdiv2")
+    supported_categories = (PUBLIC, SCHOOL)
 
     def _add_subdiv_subdiv1_holidays(self):
         self._add_holiday_aug_10("Subdiv1 Custom Holiday")
@@ -99,7 +99,14 @@ class MarketStub2(EntityStub):
 
 class TestArgs(unittest.TestCase):
     def test_categories(self):
-        self.assertRaises(NotImplementedError, lambda: CountryStub1(categories="HOME"))
+        self.assertEqual({PUBLIC}, CountryStub1(categories=PUBLIC).categories)
+        self.assertEqual({PUBLIC, SCHOOL}, CountryStub1(categories=(PUBLIC, SCHOOL)).categories)
+
+        self.assertRaises(NotImplementedError, lambda: CountryStub1(categories=OPTIONAL))
+        self.assertRaises(NotImplementedError, lambda: CountryStub1(categories="UNSUPPORTED"))
+        self.assertRaises(
+            NotImplementedError, lambda: CountryStub1(categories=("HOME", "UNSUPPORTED"))
+        )
 
     def test_country(self):
         self.assertEqual(CountryStub1().country, "CS1")


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

This PR addresses one of the concerns raised in https://github.com/vacanza/python-holidays/issues/1559

Add supported categories validation:
  - Replace set w/ tuple for specifying categories
  - Check against entity supported categories instead of all available ones
  - Remove `ALL_CATEGORIES` as unused


## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/beta/docs/source
