### PR TITLE
Extend native holiday categories support

### DIFF
--- a/holidays/countries/albania.py
+++ b/holidays/countries/albania.py
@@ -39,8 +39,7 @@ class Albania(
         kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_WORKDAY)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
+    def _populate_public_holidays(self):
         dts_observed = set()
 
         # New Year's Day.
@@ -49,11 +48,11 @@ class Albania(
         dts_observed.add(self._add_new_years_day_two(name))
 
         # Summer Day.
-        if year >= 2004:
+        if self._year >= 2004:
             dts_observed.add(self._add_holiday_mar_14("Summer Day"))
 
         # Nevruz.
-        if year >= 1996:
+        if self._year >= 1996:
             dts_observed.add(self._add_holiday_mar_22("Nevruz"))
 
         # Easter.
@@ -64,9 +63,9 @@ class Albania(
         dts_observed.add(self._add_labor_day("May Day"))
 
         # Mother Teresa Day.
-        if 2004 <= year <= 2017:
+        if 2004 <= self._year <= 2017:
             dts_observed.add(self._add_holiday_oct_19("Mother Teresa Beatification Day"))
-        elif year >= 2018:
+        elif self._year >= 2018:
             dts_observed.add(self._add_holiday_sep_5("Mother Teresa Canonization Day"))
 
         # Independence Day.
@@ -76,7 +75,7 @@ class Albania(
         dts_observed.add(self._add_holiday_nov_29("Liberation Day"))
 
         # National Youth Day.
-        if year >= 2009:
+        if self._year >= 2009:
             dts_observed.add(self._add_holiday_dec_8("National Youth Day"))
 
         # Christmas Day.

--- a/holidays/countries/algeria.py
+++ b/holidays/countries/algeria.py
@@ -32,25 +32,23 @@ class Algeria(HolidayBase, InternationalHolidays, IslamicHolidays):
         IslamicHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("رأس السنة الميلادية"))
 
         # In January 2018, Algeria declared Yennayer a national holiday.
-        if year >= 2018:
+        if self._year >= 2018:
             # Amazigh New Year / Yennayer.
             self._add_holiday_jan_12(tr("رأس السنة الأمازيغية"))
 
         # Labor Day.
         self._add_labor_day(tr("عيد العمال"))
 
-        if year >= 1962:
+        if self._year >= 1962:
             # Independence Day.
             self._add_holiday_jul_5(tr("عيد الإستقلال"))
 
-        if year >= 1963:
+        if self._year >= 1963:
             # Revolution Day.
             self._add_holiday_nov_1(tr("عيد الثورة"))
 
@@ -70,14 +68,14 @@ class Algeria(HolidayBase, InternationalHolidays, IslamicHolidays):
         self._add_eid_al_fitr_day(tr("عيد الفطر"))
         # Eid al-Fitr Holiday.
         self._add_eid_al_fitr_day_two(tr("عطلة عيد الفطر"))
-        if year >= 2024:
+        if self._year >= 2024:
             self._add_eid_al_fitr_day_three(tr("عطلة عيد الفطر"))
 
         # Eid al-Adha - Scarfice Festive.
         self._add_eid_al_adha_day(tr("عيد الأضحى"))
         # Eid al-Adha Holiday.
         self._add_eid_al_adha_day_two(tr("عطلة عيد الأضحى"))
-        if year >= 2023:
+        if self._year >= 2023:
             self._add_eid_al_adha_day_three(tr("عطلة عيد الأضحى"))
 
 

--- a/holidays/countries/american_samoa.py
+++ b/holidays/countries/american_samoa.py
@@ -20,9 +20,9 @@ class HolidaysAS(US):
     country = "AS"
     subdivisions = ()  # Override US subdivisions.
 
-    def _populate(self, year: int) -> None:
+    def _populate_public_holidays(self) -> None:
         self.subdiv = "AS"
-        super()._populate(year)
+        super()._populate_public_holidays()
 
 
 class AS(HolidaysAS):

--- a/holidays/countries/andorra.py
+++ b/holidays/countries/andorra.py
@@ -38,9 +38,7 @@ class Andorra(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year: int) -> None:
-        super()._populate(year)
-
+    def _populate_public_holidays(self) -> None:
         # New Year's Day.
         self._add_new_years_day("New Year's Day")
 

--- a/holidays/countries/angola.py
+++ b/holidays/countries/angola.py
@@ -66,22 +66,20 @@ class Angola(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         )
         return super()._add_observed(dt, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # Decree #5/75.
-        if year <= 1974:
+        if self._year <= 1974:
             return None
-
-        super()._populate(year)
 
         # New Year's Day.
         name = self.tr("Dia do Ano Novo")
         dt = self._add_new_years_day(name)
-        if year <= 2011 or year >= 2018:
+        if self._year <= 2011 or self._year >= 2018:
             self._add_observed(dt)
             self._add_observed(self._next_year_new_years_day, name=name)
 
         # Law #16/96.
-        if 1997 <= year <= 2011:
+        if 1997 <= self._year <= 2011:
             self._add_observed(
                 # Martyrs of Colonial Repression Day.
                 self._add_holiday_jan_4(tr("Dia dos Mártires da Repressão Colonial"))
@@ -90,14 +88,14 @@ class Angola(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         name = (
             # Beginning of the Armed Struggle for National Liberation Day.
             tr("Dia do Início da Luta Armada de Libertação Nacional")
-            if year >= 2012
+            if self._year >= 2012
             # Beginning of the Armed Struggle Day.
             else tr("Dia do Início da Luta Armada")
         )
         self._add_observed(self._add_holiday_feb_4(name))
 
         # Law #16/96.
-        if year >= 1997:
+        if self._year >= 1997:
             # Carnival Day.
             self._add_observed(self._add_carnival_tuesday(tr("Dia do Carnaval")))
 
@@ -105,21 +103,21 @@ class Angola(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
             self._add_observed(self._add_womens_day(tr("Dia Internacional da Mulher")))
 
         # Law #11/18.
-        if year >= 2019:
+        if self._year >= 2019:
             self._add_observed(
                 # Southern Africa Liberation Day.
                 self._add_holiday_mar_23(tr("Dia da Libertação da África Austral"))
             )
 
         # Law #7/03.
-        if year >= 2003:
+        if self._year >= 2003:
             self._add_observed(
                 # Peace and National Reconciliation Day.
                 self._add_holiday_apr_4(tr("Dia da Paz e Reconciliação Nacional"))
             )
 
         # Law #16/96.
-        if year >= 1997:
+        if self._year >= 1997:
             # Good Friday.
             self._add_good_friday(tr("Sexta-Feira Santa"))
 
@@ -127,17 +125,17 @@ class Angola(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         self._add_observed(self._add_labor_day(tr("Dia Internacional do Trabalhador")))
 
         # Law #1/01.
-        if 2001 <= year <= 2010:
+        if 2001 <= self._year <= 2010:
             # Africa Day.
             self._add_observed(self._add_africa_day(tr("Dia da África")))
 
         # Law #16/96.
-        if 1997 <= year <= 2010:
+        if 1997 <= self._year <= 2010:
             # International Children's Day.
             self._add_observed(self._add_childrens_day(tr("Dia Internacional da Criança")))
 
         # Decree #92/80.
-        if year >= 1980:
+        if self._year >= 1980:
             self._add_observed(
                 # National Heroes' Day.
                 self._add_holiday_sep_17(tr("Dia do Fundador da Nação e do Herói Nacional"))
@@ -145,37 +143,37 @@ class Angola(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
 
         # All Souls' Day.
         dt = self._add_all_souls_day(tr("Dia dos Finados"))
-        if year <= 2010 or year >= 2018:
+        if self._year <= 2010 or self._year >= 2018:
             self._add_observed(dt)
 
         name = (
             # National Independence Day.
             tr("Dia da Independência Nacional")
-            if year >= 1996
+            if self._year >= 1996
             # Independence Day.
             else tr("Dia da Independência")
         )
         self._add_observed(self._add_holiday_nov_11(name))
 
         # Decree # 7/92.
-        if year <= 1991:
+        if self._year <= 1991:
             # Date of Founding of MPLA - Labor Party.
             self._add_holiday_dec_10(tr("Data da Fundacao do MPLA - Partido do Trabalho"))
 
         name = (
             # Christmas and Family Day.
             tr("Dia de Natal e da Família")
-            if year >= 2011
+            if self._year >= 2011
             else (
                 # Christmas Day.
                 tr("Dia do Natal")
-                if year >= 1996
+                if self._year >= 1996
                 # Family Day.
                 else tr("Dia da Família")
             )
         )
         dt = self._add_christmas_day(name)
-        if year <= 2010 or year >= 2018:
+        if self._year <= 2010 or self._year >= 2018:
             self._add_observed(dt)
 
 

--- a/holidays/countries/argentina.py
+++ b/holidays/countries/argentina.py
@@ -80,9 +80,7 @@ class Argentina(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         kwargs.setdefault("observed_rule", TUE_WED_TO_PREV_MON + THU_FRI_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # Fixed Holidays
 
         # Status: In-Use.
@@ -94,7 +92,7 @@ class Argentina(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         # Started in 1956, abandoned in 1976.
         # Restarted in 2011 via Decreto 1584/2010.
 
-        if 1956 <= year <= 1975 or year >= 2011:
+        if 1956 <= self._year <= 1975 or self._year >= 2011:
             # Carnival.
             name = tr("Día de Carnaval")
             self._add_carnival_monday(name)
@@ -103,7 +101,7 @@ class Argentina(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         # Status: In-Use
         # Started in 2006, nearly reclassified as Movable Holidays in 2017
 
-        if year >= 2006:
+        if self._year >= 2006:
             self._add_holiday_mar_24(
                 # Memory's National Day for the Truth and Justice.
                 tr("Día Nacional de la Memoria por la Verdad y la Justicia")
@@ -115,15 +113,15 @@ class Argentina(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         # Superseded "Day of Argentine Sovereignty over the Malvinas".
         # Got moved temporary in 2020 (Decreto 297/2020).
 
-        if year >= 1993:
+        if self._year >= 1993:
             name = (
                 # War Veterans Day.
                 tr("Día del Veterano de Guerra")
-                if year <= 2000
+                if self._year <= 2000
                 # Veterans Day and the Fallen in the Malvinas War.
                 else tr("Día del Veterano y de los Caidos en la Guerra de Malvinas")
             )
-            if year == 2020:
+            if self._year == 2020:
                 self._add_holiday_mar_31(name)
             else:
                 self._add_holiday_apr_2(name)
@@ -131,11 +129,11 @@ class Argentina(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         # Good Friday.
         self._add_good_friday(tr("Viernes Santo"))
 
-        if year >= 1930:
+        if self._year >= 1930:
             # Labor Day.
             self._add_labor_day(tr("Día del Trabajo"))
 
-        if year >= 1813:
+        if self._year >= 1813:
             # May Revolution Day.
             self._add_holiday_may_25(tr("Día de la Revolución de Mayo"))
 
@@ -144,14 +142,14 @@ class Argentina(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         # Abandoned in 2001.
         # Superseded by "Veterans Day and the Fallen in the Malvinas War".
 
-        if 1983 <= year <= 2000:
+        if 1983 <= self._year <= 2000:
             # Day of Argentine Sovereignty over the Malvinas, Sandwich and
             # South Atlantic Islands.
             name = tr(
                 "Día de los Derechos Argentinos sobre las Islas Malvinas, "
                 "Sandwich y del Atlántico Sur"
             )
-            if year == 1983:
+            if self._year == 1983:
                 self._add_holiday_apr_2(name)
             else:
                 self._add_holiday_jun_10(name)
@@ -162,16 +160,16 @@ class Argentina(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         # Set as 3rd MON of JUN via Ley 24455 in Dec 1994.
         # Made Fixed Holiday again in 2011.
 
-        if year >= 1938:
+        if self._year >= 1938:
             # Pass to the Immortality of General Don Manuel Belgrano.
             name = tr("Paso a la Inmortalidad del General Don Manuel Belgrano")
 
-            if 1995 <= year <= 2010:
+            if 1995 <= self._year <= 2010:
                 self._add_holiday_3rd_mon_of_jun(name)
             else:
                 self._add_holiday_jun_20(name)
 
-        if year >= 1816:
+        if self._year >= 1816:
             # Independence Day.
             self._add_holiday_jul_9(tr("Día de la Independencia"))
 
@@ -186,7 +184,7 @@ class Argentina(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         # Status: In-Use.
         # Started in 2014 for Salta, 2016 for the whole country via Ley 27258.
 
-        if year >= 2016:
+        if self._year >= 2016:
             jun_17 = self._add_holiday_jun_17(
                 # Pass to the Immortality of General Don Martin Miguel de Guemes.
                 tr("Paso a la Inmortalidad del General Don Martín Miguel de Güemes"),
@@ -202,29 +200,29 @@ class Argentina(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
 
         # Pass to the Immortality of General Don Jose de San Martin.
         name = tr("Paso a la Inmortalidad del General Don José de San Martin")
-        if year == 2011:
+        if self._year == 2011:
             self._add_holiday_aug_22(name)
-        elif 1938 <= year <= 1994:
+        elif 1938 <= self._year <= 1994:
             self._add_holiday_aug_17(name)
-        elif 1995 <= year <= 2010:
+        elif 1995 <= self._year <= 2010:
             self._add_holiday_3rd_mon_of_aug(name)
-        elif year >= 2012:
+        elif self._year >= 2012:
             self._move_holiday(self._add_holiday_aug_17(name))
 
         # Status: In-Use.
         # First started in 1917 for Argentina.
         # In 2010 the holiday became movable and its name was changed.
 
-        if year >= 1917:
+        if self._year >= 1917:
             name = (
                 # Respect for Cultural Diversity Day.
                 tr("Día del Respeto a la Diversidad Cultural")
-                if year >= 2010
+                if self._year >= 2010
                 # Columbus Day.
                 else tr("Día de la Raza")
             )
             oct_12 = self._add_columbus_day(name)
-            if year >= 2010:
+            if self._year >= 2010:
                 self._move_holiday(oct_12)
 
         # Status: In-Use.
@@ -233,12 +231,12 @@ class Argentina(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         # Moved to Nov 27 for 2015 (election interfere).
         # Moved to Nov 28 again for 2016.
 
-        if year >= 2010:
+        if self._year >= 2010:
             # National Sovereignty Day.
             name = tr("Día de la Soberanía Nacional")
-            if year == 2015:
+            if self._year == 2015:
                 self._add_holiday_nov_27(name)
-            elif year == 2016:
+            elif self._year == 2016:
                 self._add_holiday_nov_28(name)
             else:
                 self._move_holiday(self._add_holiday_nov_20(name))

--- a/holidays/countries/armenia.py
+++ b/holidays/countries/armenia.py
@@ -35,11 +35,9 @@ class Armenia(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1990:
+    def _populate_public_holidays(self):
+        if self._year <= 1990:
             return None
-
-        super()._populate(year)
 
         # New Year's Day.
         name = tr("Նոր տարվա օր")
@@ -49,7 +47,7 @@ class Armenia(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Christmas. Epiphany Day.
         self._add_holiday_jan_6(tr("Սուրբ Ծնունդ եւ Հայտնություն"))
 
-        if 2010 <= year <= 2021:
+        if 2010 <= self._year <= 2021:
             self._add_new_years_day_three(name)
             self._add_new_years_day_four(name)
 
@@ -59,41 +57,41 @@ class Armenia(HolidayBase, ChristianHolidays, InternationalHolidays):
             # The Day of Remembrance of the Dead.
             self._add_holiday_jan_7(tr("Մեռելոց հիշատակի օր"))
 
-        if year >= 2003:
+        if self._year >= 2003:
             # Army Day.
             self._add_holiday_jan_28(tr("Բանակի օր"))
 
         # Women's Day.
         self._add_womens_day(tr("Կանանց տոն"))
 
-        if 1994 <= year <= 2001:
+        if 1994 <= self._year <= 2001:
             # Motherhood and Beauty Day.
             self._add_holiday_apr_7(tr("Մայրության և գեղեցկության տոն"))
 
         # Armenian Genocide Remembrance Day,
         self._add_holiday_apr_24(tr("Եղեռնի զոհերի հիշատակի օր"))
 
-        if year >= 2001:
+        if self._year >= 2001:
             self._add_labor_day(
                 # Labor Day.
                 tr("Աշխատանքի օր")
-                if year >= 2002
+                if self._year >= 2002
                 # International Day of Workers' Solidarity.
                 else tr("Աշխատավորների համերաշխության միջազգային օր")
             )
 
-        if year >= 1995:
+        if self._year >= 1995:
             # Victory and Peace Day.
             self._add_world_war_two_victory_day(tr("Հաղթանակի և Խաղաղության տոն"))
 
         # Republic Day.
         self._add_holiday_may_28(tr("Հանրապետության օր"))
 
-        if year >= 1996:
+        if self._year >= 1996:
             # Constitution Day.
             self._add_holiday_jul_5(tr("Սահմանադրության օր"))
 
-        if year >= 1992:
+        if self._year >= 1992:
             # Independence Day.
             self._add_holiday_sep_21(tr("Անկախության օր"))
 

--- a/holidays/countries/aruba.py
+++ b/holidays/countries/aruba.py
@@ -38,12 +38,10 @@ class Aruba(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # AUG 1947: Autonomous State status in the Kingdom of the Netherlands.
-        if year <= 1946:
+        if self._year <= 1946:
             return None
-
-        super()._populate(year)
 
         # Aña Nobo.
         # Status: In-Use.
@@ -55,7 +53,7 @@ class Aruba(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Status: In-Use.
         # Started in 1989.
 
-        if year >= 1989:
+        if self._year >= 1989:
             # Betico Day
             self._add_holiday_jan_25(tr("Dia di Betico"))
 
@@ -65,11 +63,11 @@ class Aruba(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Event cancelled but remain a holiday in 2021.
         # Have its name changed from 2023 onwards.
 
-        if year >= 1956:
+        if self._year >= 1956:
             self._add_ash_monday(
                 # Carnival Monday
                 tr("Dialuna despues di Carnaval Grandi")
-                if year <= 2022
+                if self._year <= 2022
                 # Monday before Ash Wednesday
                 else tr("Dialuna prome cu diaranson di shinish")
             )
@@ -78,7 +76,7 @@ class Aruba(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Status: In-Use.
         # Started in 1976.
 
-        if year >= 1976:
+        if self._year >= 1976:
             # National Anthem and Flag Day
             self._add_holiday_mar_18(tr("Dia di Himno y Bandera"))
 
@@ -105,23 +103,23 @@ class Aruba(HolidayBase, ChristianHolidays, InternationalHolidays):
         name = (
             # King's Day.
             tr("Dia di Rey")
-            if year >= 2021
+            if self._year >= 2021
             else (
                 # King's Day.
                 tr("Aña di Rey")
-                if year >= 2014
+                if self._year >= 2014
                 # Queen's Day.
                 else tr("Aña di La Reina")
             )
         )
-        if year >= 2014:
+        if self._year >= 2014:
             dt = (APR, 27)
-        elif year >= 1949:
+        elif self._year >= 1949:
             dt = (APR, 30)
         else:
             dt = (AUG, 31)
         if self._is_sunday(dt):
-            dt = date(self._year, *dt) + td(days=-1 if year >= 1980 else +1)
+            dt = date(self._year, *dt) + td(days=-1 if self._year >= 1980 else +1)
         self._add_holiday(name, dt)
 
         # Dia di Labor/Dia di Obrero.

--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -45,9 +45,7 @@ class Australia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # ACT:  Holidays Act 1958
         # NSW:  Public Holidays Act 2010
         # NT:   Public Holidays Act 2013
@@ -67,7 +65,7 @@ class Australia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, S
         self._add_easter_monday("Easter Monday")
 
         # Sovereign's Birthday
-        if 1902 <= year <= 1935:
+        if 1902 <= self._year <= 1935:
             if self._year >= 1912:
                 self._add_holiday_jun_3(self.sovereign_birthday)  # George V
             else:

--- a/holidays/countries/bahrain.py
+++ b/holidays/countries/bahrain.py
@@ -38,9 +38,7 @@ class Bahrain(HolidayBase, InternationalHolidays, IslamicHolidays):
         IslamicHolidays.__init__(self, cls=BahrainIslamicHolidays)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("رأس السنة الميلادية"))
 

--- a/holidays/countries/bangladesh.py
+++ b/holidays/countries/bangladesh.py
@@ -27,9 +27,7 @@ class Bangladesh(HolidayBase, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # International Mother's language Day.
         self._add_holiday_feb_21("International Mother's language Day")
 

--- a/holidays/countries/barbados.py
+++ b/holidays/countries/barbados.py
@@ -40,17 +40,16 @@ class Barbados(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, St
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # Public Holidays Act Cap.352, 1968-12-30
-        if year <= 1968:
+        if self._year <= 1968:
             return None
-        super()._populate(year)
 
         # New Year's Day
         self._add_observed(self._add_new_years_day("New Year's Day"))
 
         # Errol Barrow Day
-        if year >= 1989:
+        if self._year >= 1989:
             self._add_observed(self._add_holiday_jan_21("Errol Barrow Day"))
 
         # Good Friday
@@ -60,7 +59,7 @@ class Barbados(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, St
         self._add_easter_monday("Easter Monday")
 
         # National Heroes Day
-        if year >= 1998:
+        if self._year >= 1998:
             self._add_observed(self._add_holiday_apr_28("National Heroes Day"))
 
         # May Day

--- a/holidays/countries/belarus.py
+++ b/holidays/countries/belarus.py
@@ -39,17 +39,15 @@ class Belarus(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolid
         StaticHolidays.__init__(self, BelarusStaticHolidays)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # The current set of holidays actual from 1998.
-        if year <= 1997:
+        if self._year <= 1997:
             return None
-
-        super()._populate(year)
 
         # New Year's Day.
         self._add_new_years_day(tr("Новы год"))
 
-        if year >= 2020:
+        if self._year >= 2020:
             self._add_new_years_day_two(tr("Новы год"))
 
         # Orthodox Christmas Day.

--- a/holidays/countries/belize.py
+++ b/holidays/countries/belize.py
@@ -40,16 +40,15 @@ class Belize(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # Belize was granted independence on 21.09.1981.
-        if year <= 1981:
+        if self._year <= 1981:
             return None
-        super()._populate(year)
 
         # New Year's Day.
         self._move_holiday(self._add_new_years_day("New Year's Day"))
 
-        if year >= 2021:
+        if self._year >= 2021:
             # George Price Day.
             self._move_holiday(self._add_holiday_jan_15("George Price Day"))
 
@@ -71,14 +70,14 @@ class Belize(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         # Labour Day.
         self._move_holiday(self._add_labor_day("Labour Day"))
 
-        if year <= 2021:
+        if self._year <= 2021:
             # Commonwealth Day.
             self._move_holiday(
                 self._add_holiday_may_24("Commonwealth Day"),
                 rule=TUE_WED_THU_TO_PREV_MON + FRI_SUN_TO_NEXT_MON,
             )
 
-        if year >= 2021:
+        if self._year >= 2021:
             # Emancipation Day.
             self._move_holiday(
                 self._add_holiday_aug_1("Emancipation Day"),
@@ -92,7 +91,7 @@ class Belize(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         self._move_holiday(self._add_holiday_sep_21("Independence Day"))
 
         # Indigenous Peoples' Resistance Day / Pan American Day.
-        name = "Indigenous Peoples' Resistance Day" if year >= 2021 else "Pan American Day"
+        name = "Indigenous Peoples' Resistance Day" if self._year >= 2021 else "Pan American Day"
         self._move_holiday(
             self._add_columbus_day(name), rule=TUE_WED_THU_TO_PREV_MON + FRI_SUN_TO_NEXT_MON
         )

--- a/holidays/countries/bolivia.py
+++ b/holidays/countries/bolivia.py
@@ -61,17 +61,15 @@ class Bolivia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         kwargs.setdefault("observed_since", 1977)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1824:
+    def _populate_public_holidays(self):
+        if self._year <= 1824:
             return None
-
-        super()._populate(year)
 
         # New Year's Day.
         self._add_observed(self._add_new_years_day(tr("Año Nuevo")))
 
         # Supreme Decree #0405.
-        if year >= 2010:
+        if self._year >= 2010:
             self._add_observed(
                 self._add_holiday_jan_22(
                     # Plurinational State Foundation Day.
@@ -90,34 +88,34 @@ class Bolivia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         # Labor Day.
         self._add_observed(may_1 := self._add_labor_day(self.tr("Día del Trabajo")))
         # Supreme Decree #1210.
-        if 2012 <= year <= 2015:
+        if 2012 <= self._year <= 2015:
             self._add_observed(may_1, rule=TUE_TO_PREV_MON + THU_TO_NEXT_FRI)
 
         # Corpus Christi.
         self._add_corpus_christi_day(tr("Corpus Christi"))
 
         # Supreme Decree #0173.
-        if year >= 2009:
+        if self._year >= 2009:
             # Aymara New Year.
             self._add_observed(self._add_holiday_jun_21(tr("Año Nuevo Aymara Amazónico")))
 
         # Independence Day.
         self._add_observed(self._add_holiday_aug_6(tr("Día de la Independencia de Bolivia")))
 
-        if year >= 2020:
+        if self._year >= 2020:
             # National Dignity Day.
             self._add_holiday_oct_17(tr("Día de la Dignidad Nacional"))
 
         # Supreme Decree #21060.
-        if 1985 <= year <= 1988:
+        if 1985 <= self._year <= 1988:
             # All Saints' Day.
             self._add_all_saints_day(tr("Día de Todos los Santos"))
 
         # Supreme Decree #22352.
-        if year >= 1989:
+        if self._year >= 1989:
             # All Souls' Day.
             nov_2 = self._add_all_souls_day(tr("Día de Todos los Difuntos"))
-            if year <= 2015:
+            if self._year <= 2015:
                 self._add_observed(nov_2)
 
         # Christmas Day.

--- a/holidays/countries/bosnia_and_herzegovina.py
+++ b/holidays/countries/bosnia_and_herzegovina.py
@@ -77,9 +77,7 @@ class BosniaAndHerzegovina(
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # Orthodox Good Friday.
         self._add_good_friday(tr("Veliki petak (Pravoslavni)"))
 

--- a/holidays/countries/botswana.py
+++ b/holidays/countries/botswana.py
@@ -35,11 +35,9 @@ class Botswana(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, St
         kwargs.setdefault("observed_since", 1995)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1965:
+    def _populate_public_holidays(self):
+        if self._year <= 1965:
             return None
-
-        super()._populate(year)
 
         self._add_observed(self._add_new_years_day("New Year's Day"), rule=SUN_TO_NEXT_TUE)
         self._add_observed(self._add_new_years_day_two("New Year's Day Holiday"))
@@ -52,7 +50,7 @@ class Botswana(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, St
 
         may_1 = self._add_labor_day("Labour Day")
         self._add_observed(may_1)
-        if self.observed and year >= 2016 and self._is_saturday(may_1):
+        if self.observed and self._year >= 2016 and self._is_saturday(may_1):
             self._add_labor_day_three("Labour Day Holiday")
 
         self._add_observed(self._add_holiday_jul_1("Sir Seretse Khama Day"))
@@ -67,7 +65,7 @@ class Botswana(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, St
         self._add_observed(self._add_christmas_day("Christmas Day"), rule=SUN_TO_NEXT_TUE)
         self._add_observed(dec_26 := self._add_christmas_day_two("Boxing Day"))
 
-        if self.observed and year >= 2016 and self._is_saturday(dec_26):
+        if self.observed and self._year >= 2016 and self._is_saturday(dec_26):
             self._add_holiday("Boxing Day Holiday", dec_26 + td(days=+2))
 
 

--- a/holidays/countries/brunei.py
+++ b/holidays/countries/brunei.py
@@ -80,12 +80,10 @@ class Brunei(
         kwargs.setdefault("observed_rule", FRI_SUN_TO_NEXT_SAT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # Available post-Independence from 1984 afterwards
-        if year <= 1983:
+        if self._year <= 1983:
             return None
-
-        super()._populate(year)
 
         # Awal Tahun Masihi
         # Status: In-Use.

--- a/holidays/countries/burkina_faso.py
+++ b/holidays/countries/burkina_faso.py
@@ -31,18 +31,16 @@ class BurkinaFaso(ObservedHolidayBase, ChristianHolidays, InternationalHolidays,
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # On 5 August 1960, Burkina Faso (Republic of Upper Volta at that time)
         # gained independence from France.
-        if year <= 1960:
+        if self._year <= 1960:
             return None
-
-        super()._populate(year)
 
         # New Year's Day.
         self._add_observed(self._add_new_years_day("New Year's Day"))
 
-        if year >= 1967:
+        if self._year >= 1967:
             # Revolution Day.
             self._add_observed(self._add_holiday_jan_3("Revolution Day"))
 
@@ -64,7 +62,7 @@ class BurkinaFaso(ObservedHolidayBase, ChristianHolidays, InternationalHolidays,
         # Assumption Day.
         self._add_observed(self._add_assumption_of_mary_day("Assumption Day"))
 
-        if year >= 2016:
+        if self._year >= 2016:
             # Martyrs' Day.
             self._add_observed(self._add_holiday_oct_31("Martyrs' Day"))
 

--- a/holidays/countries/burundi.py
+++ b/holidays/countries/burundi.py
@@ -35,21 +35,19 @@ class Burundi(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Isl
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1961:
+    def _populate_public_holidays(self):
+        if self._year <= 1961:
             return None
-
-        super()._populate(year)
 
         # New Year's Day
         self._add_observed(self._add_new_years_day("New Year's Day"))
 
         # Unity Day
-        if year >= 1992:
+        if self._year >= 1992:
             self._add_observed(self._add_holiday_feb_5("Unity Day"))
 
         # President Ntaryamira Day
-        if year >= 1995:
+        if self._year >= 1995:
             self._add_observed(self._add_holiday_apr_6("President Ntaryamira Day"))
 
         # Labour Day
@@ -59,7 +57,7 @@ class Burundi(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Isl
         self._add_ascension_thursday("Ascension Day")
 
         # President Nkurunziza Day
-        if year >= 2022:
+        if self._year >= 2022:
             self._add_observed(self._add_holiday_jun_8("President Nkurunziza Day"))
 
         # Independence Day
@@ -72,7 +70,7 @@ class Burundi(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Isl
         self._add_observed(self._add_holiday_oct_13("Prince Louis Rwagasore Day"))
 
         # President Ndadaye's Day
-        if year >= 1994:
+        if self._year >= 1994:
             self._add_observed(self._add_holiday_oct_21("President Ndadaye's Day"))
 
         # All Saints' Day

--- a/holidays/countries/cambodia.py
+++ b/holidays/countries/cambodia.py
@@ -58,12 +58,10 @@ class Cambodia(HolidayBase, InternationalHolidays, StaticHolidays, ThaiCalendarH
         ThaiCalendarHolidays.__init__(self, KHMER_CALENDAR)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # Available post-Independence from 1993 afterwards
-        if year <= 1992:
+        if self._year <= 1992:
             return None
-
-        super()._populate(year)
 
         # Fixed Holidays
 
@@ -88,15 +86,15 @@ class Cambodia(HolidayBase, InternationalHolidays, StaticHolidays, ThaiCalendarH
 
         #  ពិធីបុណ្យចូលឆ្នាំថ្មីប្រពៃណីជាតិ
         # Status: In-Use.
-        # Usually falls on April 13th except for 2017-2018 and 2021-2023 for years 2001-2050.
+        # Usually falls on April 13th except for 2017-2018 and 2021-2023 for self._years 2001-2050.
 
-        if year != 2020:
+        if self._year != 2020:
             # Khmer New Year's Day
             sangkranta = tr("ពិធីបុណ្យចូលឆ្នាំថ្មីប្រពៃណីជាតិ")
             sangkranta_years_apr_14 = {2017, 2018, 2021, 2022, 2023}
             dt = (
                 self._add_holiday_apr_14(sangkranta)
-                if year in sangkranta_years_apr_14
+                if self._year in sangkranta_years_apr_14
                 else self._add_holiday_apr_13(sangkranta)
             )
             self._add_holiday(sangkranta, dt + td(days=+1))
@@ -112,14 +110,14 @@ class Cambodia(HolidayBase, InternationalHolidays, StaticHolidays, ThaiCalendarH
         # Status: In-Use.
         # Assumed to start in 2005. Was celebrated for 3 days until 2020.
 
-        if year >= 2005:
+        if self._year >= 2005:
             king_sihamoni_bday = tr(
                 # Birthday of His Majesty Preah Bat Samdech Preah Boromneath
                 # NORODOM SIHAMONI, King of Cambodia
                 "ព្រះរាជពិធីបុណ្យចម្រើនព្រះជន្ម ព្រះករុណា ព្រះបាទសម្តេចព្រះបរមនាថ នរោត្តម សីហមុនី"
             )
             dt = self._add_holiday_may_14(king_sihamoni_bday)
-            if year <= 2019:
+            if self._year <= 2019:
                 self._add_holiday_may_13(king_sihamoni_bday)
                 self._add_holiday_may_15(king_sihamoni_bday)
 
@@ -130,7 +128,7 @@ class Cambodia(HolidayBase, InternationalHolidays, StaticHolidays, ThaiCalendarH
         # Its celebration was put onhold by UN administration with
         # its name changed to present one in 2001.
 
-        if 2018 <= year <= 2019:
+        if 2018 <= self._year <= 2019:
             # National Day of Remembrance
             self._add_holiday_may_20(tr("ទិវាជាតិនៃការចងចាំ"))
 
@@ -138,7 +136,7 @@ class Cambodia(HolidayBase, InternationalHolidays, StaticHolidays, ThaiCalendarH
         # Status: Defunct.
         # Assumed to start in 1993, defunct from 2020 onwards.
 
-        if year <= 2019:
+        if self._year <= 2019:
             # International Children Day
             self._add_childrens_day(tr("ទិវាកុមារអន្តរជាតិ"))
 
@@ -146,7 +144,7 @@ class Cambodia(HolidayBase, InternationalHolidays, StaticHolidays, ThaiCalendarH
         # Status: In-Use.
         # Assumed to start in 1994. A public holiday since 2015 at least.
 
-        if year >= 1994:
+        if self._year >= 1994:
             self._add_holiday_jun_18(
                 # Birthday of Her Majesty the Queen-Mother NORODOM MONINEATH SIHANOUK of Cambodia
                 tr(
@@ -167,7 +165,7 @@ class Cambodia(HolidayBase, InternationalHolidays, StaticHolidays, ThaiCalendarH
         # Status: In-Use.
         # Starts in 2012.
 
-        if year >= 2012:
+        if self._year >= 2012:
             self._add_holiday_oct_15(
                 # Mourning Day of the Late King-Father
                 # NORODOM SIHANOUK of Cambodia
@@ -182,7 +180,7 @@ class Cambodia(HolidayBase, InternationalHolidays, StaticHolidays, ThaiCalendarH
         # Status: Defunct.
         # Assumed to start in 1993, defunct from 2020 onwards.
 
-        if year <= 2019:
+        if self._year <= 2019:
             # Paris Peace Agreement's Day
             self._add_holiday_oct_23(tr("ទិវារំលឹកសន្ធិសញ្ញាសន្តិភាពទីក្រុងប៉ារីស"))
 
@@ -192,7 +190,7 @@ class Cambodia(HolidayBase, InternationalHolidays, StaticHolidays, ThaiCalendarH
         # Status: In-Use.
         # Starts in 2004.
 
-        if year >= 2004:
+        if self._year >= 2004:
             self._add_holiday_oct_29(
                 # Coronation Day of His Majesty Preah Bat Samdech Preah
                 # Boromneath NORODOM SIHAMONI, King of Cambodia
@@ -214,7 +212,7 @@ class Cambodia(HolidayBase, InternationalHolidays, StaticHolidays, ThaiCalendarH
         # Status: Defunct.
         # Assumed to start in 1993, defunct from 2020 onwards.
 
-        if year <= 2019:
+        if self._year <= 2019:
             # International Human Rights Day
             self._add_holiday_dec_10(tr("ទិវាសិទ្ធិមនុស្សអន្តរជាតិ"))
 
@@ -227,7 +225,7 @@ class Cambodia(HolidayBase, InternationalHolidays, StaticHolidays, ThaiCalendarH
         # 15th Waxing Day of Month 3.
         # Defunct from 2020 onwards.
 
-        if year <= 2019:
+        if self._year <= 2019:
             # Meak Bochea Day
             self._add_makha_bucha(tr("ពិធីបុណ្យមាឃបូជា"))
 
@@ -258,7 +256,7 @@ class Cambodia(HolidayBase, InternationalHolidays, StaticHolidays, ThaiCalendarH
         pchum_ben_date = self._add_pchum_ben(pchum_ben)
         if pchum_ben_date:
             self._add_holiday(pchum_ben, pchum_ben_date + td(days=-1))
-            if year >= 2017:
+            if self._year >= 2017:
                 self._add_holiday(pchum_ben, pchum_ben_date + td(days=+1))
 
         # ព្រះរាជពិធីបុណ្យអុំទូក បណ្តែតប្រទីប និងសំពះព្រះខែអកអំបុក

--- a/holidays/countries/cameroon.py
+++ b/holidays/countries/cameroon.py
@@ -41,19 +41,18 @@ class Cameroon(
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_WORKDAY)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # On 1 January 1960, French Cameroun gained independence from France.
-        if year <= 1959:
+        if self._year <= 1959:
             return None
 
-        super()._populate(year)
         dts_observed = set()
 
         # New Year's Day.
         dts_observed.add(self._add_new_years_day("New Year's Day"))
 
         # Youth Day.
-        if year >= 1966:
+        if self._year >= 1966:
             dts_observed.add(self._add_holiday_feb_11("Youth Day"))
 
         # Good Friday.
@@ -63,7 +62,7 @@ class Cameroon(
         dts_observed.add(self._add_labor_day("Labour Day"))
 
         # National Day.
-        if year >= 1972:
+        if self._year >= 1972:
             dts_observed.add(self._add_holiday_may_20("National Day"))
 
         # Ascension Day.

--- a/holidays/countries/chad.py
+++ b/holidays/countries/chad.py
@@ -40,12 +40,10 @@ class Chad(
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # On 11 August 1960, Chad gained independence from France.
-        if year <= 1960:
+        if self._year <= 1960:
             return None
-
-        super()._populate(year)
 
         # New Year's Day.
         self._add_observed(self._add_new_years_day("New Year's Day"))
@@ -68,7 +66,7 @@ class Chad(
         # Republic Day.
         self._add_observed(self._add_holiday_nov_28("Republic Day"))
 
-        if year >= 1991:
+        if self._year >= 1991:
             # Freedom and Democracy Day.
             self._add_observed(self._add_holiday_dec_1("Freedom and Democracy Day"))
 

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -79,15 +79,13 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         kwargs.setdefault("observed_since", 2000)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1914:
+    def _populate_public_holidays(self):
+        if self._year <= 1914:
             return None
-
-        super()._populate(year)
 
         # New Year's Day.
         jan_1 = self._add_new_years_day(tr("Año Nuevo"))
-        if year >= 2017 and self._is_sunday(jan_1):
+        if self._year >= 2017 and self._is_sunday(jan_1):
             self._add_new_years_day_two(tr("Feriado nacional"))
 
         # Good Friday.
@@ -96,57 +94,57 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         # Holy Saturday.
         self._add_holy_saturday(tr("Sábado Santo"))
 
-        if year <= 1967:
+        if self._year <= 1967:
             # Ascension of Jesus.
             self._add_ascension_thursday(tr("Ascensión del Señor"))
 
-        if year <= 1967 or 1987 <= year <= 2006:
+        if self._year <= 1967 or 1987 <= self._year <= 2006:
             self._add_holiday(
                 # Corpus Christi.
                 tr("Corpus Christi"),
-                self._easter_sunday + td(days=+60 if year <= 1999 else +57),
+                self._easter_sunday + td(days=+60 if self._year <= 1999 else +57),
             )
 
-        if year >= 1932:
+        if self._year >= 1932:
             # Labour Day.
             self._add_labor_day(tr("Día Nacional del Trabajo"))
 
         # Naval Glories Day.
         self._add_holiday_may_21(tr("Día de las Glorias Navales"))
 
-        if year >= 2021:
+        if self._year >= 2021:
             # National Day of Indigenous Peoples.
             name = tr("Día Nacional de los Pueblos Indígenas")
-            if year == 2021:
+            if self._year == 2021:
                 self._add_holiday_jun_21(name)
             else:
                 self._add_holiday(name, self._summer_solstice_date)
 
-        if year <= 1967 or year >= 1986:
+        if self._year <= 1967 or self._year >= 1986:
             # Saint Peter and Saint Paul.
             self._move_holiday(self._add_saints_peter_and_paul_day(tr("San Pedro y San Pablo")))
 
-        if year >= 2007:
+        if self._year >= 2007:
             # Day of Virgin of Carmen.
             self._add_holiday_jul_16(tr("Virgen del Carmen"))
 
         # Assumption of Mary.
         self._add_assumption_of_mary_day(tr("Asunción de la Virgen"))
 
-        if 1981 <= year <= 1998:
+        if 1981 <= self._year <= 1998:
             # Day of National Liberation.
             self._add_holiday_sep_11(tr("Día de la Liberación Nacional"))
-        elif 1999 <= year <= 2001:
+        elif 1999 <= self._year <= 2001:
             self._add_holiday_1st_mon_of_sep(
                 # Day of National Unity.
                 tr("Día de la Unidad Nacional")
             )
 
-        if year >= 2017 and self._is_saturday(SEP, 18):
+        if self._year >= 2017 and self._is_saturday(SEP, 18):
             # National Holiday.
             self._add_holiday_sep_17(tr("Fiestas Patrias"))
 
-        if year >= 2007 and self._is_tuesday(SEP, 18):
+        if self._year >= 2007 and self._is_tuesday(SEP, 18):
             self._add_holiday_sep_17(tr("Fiestas Patrias"))
 
         # Independence Day.
@@ -155,23 +153,23 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         # Army Day.
         self._add_holiday_sep_19(tr("Día de las Glorias del Ejército"))
 
-        if year >= 2008 and self._is_thursday(SEP, 19):
+        if self._year >= 2008 and self._is_thursday(SEP, 19):
             self._add_holiday_sep_20(tr("Fiestas Patrias"))
 
-        if 1932 <= year <= 1944:
+        if 1932 <= self._year <= 1944:
             self._add_holiday_sep_20(tr("Fiestas Patrias"))
 
-        if year >= 1922 and year != 1973:
+        if self._year >= 1922 and self._year != 1973:
             name = (
                 # Meeting of Two Worlds' Day.
                 tr("Día del Encuentro de dos Mundos")
-                if year >= 2000
+                if self._year >= 2000
                 # Columbus Day.
                 else tr("Día de la Raza")
             )
             self._move_holiday(self._add_columbus_day(name))
 
-        if year >= 2008:
+        if self._year >= 2008:
             # This holiday is moved to the preceding Friday if it falls on a Tuesday,
             # or to the following Friday if it falls on a Wednesday.
             self._move_holiday(
@@ -188,7 +186,7 @@ class Chile(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         # Immaculate Conception.
         self._add_immaculate_conception_day(tr("La Inmaculada Concepción"))
 
-        if 1944 <= year <= 1988:
+        if 1944 <= self._year <= 1988:
             # Christmas Eve.
             self._add_christmas_eve(tr("Víspera de Navidad"))
 

--- a/holidays/countries/china.py
+++ b/holidays/countries/china.py
@@ -283,7 +283,7 @@ class China(HolidayBase, ChineseCalendarHolidays, InternationalHolidays, StaticH
             # Status: In-Use (Statutory).
             # Mid-Autumn Festival in 2007, and 2013 revision.
             # Consecutive Holidays are available from 2008, except in 2010/2014/2015/2018/2019.
-            # Extra Day (Oct 8) is instead aded to the National Day Week if overlaps.
+            # Extra Day (Oct 8) is instead added to the National Day Week if overlaps.
 
             # Mid-Autumn Festival.
             mid_autumn_festival = self._add_mid_autumn_festival(tr("中秋节"))

--- a/holidays/countries/colombia.py
+++ b/holidays/countries/colombia.py
@@ -51,13 +51,11 @@ class Colombia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         kwargs.setdefault("observed_since", 1984)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("Año Nuevo"))
 
-        if year >= 1951:
+        if self._year >= 1951:
             # Epiphany.
             self._move_holiday(self._add_epiphany_day(tr("Día de los Reyes Magos")))
 
@@ -79,13 +77,13 @@ class Colombia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         # Labor Day.
         self._add_labor_day(tr("Día del Trabajo"))
 
-        if year >= 1984:
+        if self._year >= 1984:
             self._move_holiday(
                 # Sacred Heart.
                 self._add_holiday(tr("Sagrado Corazón"), self._easter_sunday + td(days=+68))
             )
 
-        if year >= 1951:
+        if self._year >= 1951:
             # Saint Peter and Saint Paul's Day.
             self._move_holiday(self._add_saints_peter_and_paul_day(tr("San Pedro y San Pablo")))
 
@@ -95,14 +93,14 @@ class Colombia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         # Battle of Boyaca.
         self._add_holiday_aug_7(tr("Batalla de Boyacá"))
 
-        if year >= 1951:
+        if self._year >= 1951:
             # Assumption of Mary.
             self._move_holiday(self._add_assumption_of_mary_day(tr("La Asunción")))
 
         # Columbus Day.
         self._move_holiday(self._add_columbus_day(tr("Día de la Raza")))
 
-        if year >= 1951:
+        if self._year >= 1951:
             # All Saints' Day.
             self._move_holiday(self._add_all_saints_day(tr("Día de Todos los Santos")))
 
@@ -111,7 +109,7 @@ class Colombia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
             self._add_holiday_nov_11(tr("Independencia de Cartagena"))
         )
 
-        if year >= 1951:
+        if self._year >= 1951:
             # Immaculate Conception.
             self._add_immaculate_conception_day(tr("La Inmaculada Concepción"))
 

--- a/holidays/countries/costa_rica.py
+++ b/holidays/countries/costa_rica.py
@@ -44,9 +44,7 @@ class CostaRica(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         kwargs.setdefault("observed_rule", ALL_TO_NEAREST_MON_LATAM)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("Año Nuevo"))
 
@@ -58,21 +56,21 @@ class CostaRica(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
 
         # Juan Santamaría Day.
         apr_11 = self._add_holiday_apr_11(tr("Día de Juan Santamaría"))
-        if 2006 <= year <= 2010:
+        if 2006 <= self._year <= 2010:
             self._move_holiday(apr_11, rule=WORKDAY_TO_NEXT_MON)
-        elif year in {2023, 2024}:
+        elif self._year in {2023, 2024}:
             self._move_holiday(apr_11)
 
         # International Labor Day.
         dt = self._add_labor_day(tr("Día Internacional del Trabajo"))
-        if year == 2021:
+        if self._year == 2021:
             self._move_holiday(dt)
 
         # Annexation of the Party of Nicoya to Costa Rica.
         jul_25 = self._add_holiday_jul_25(tr("Anexión del Partido de Nicoya a Costa Rica"))
-        if 2005 <= year <= 2008:
+        if 2005 <= self._year <= 2008:
             self._move_holiday(jul_25, rule=WORKDAY_TO_NEXT_MON)
-        elif 2020 <= year <= 2024:
+        elif 2020 <= self._year <= 2024:
             self._move_holiday(jul_25)
 
         # Feast of Our Lady of the Angels.
@@ -80,36 +78,36 @@ class CostaRica(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
 
         # Mother's Day.
         dt = self._add_assumption_of_mary_day(tr("Día de la Madre"))
-        if 2005 <= year <= 2007:
+        if 2005 <= self._year <= 2007:
             self._move_holiday(dt, rule=WORKDAY_TO_NEXT_MON)
-        elif year in {2020, 2023, 2024}:
+        elif self._year in {2020, 2023, 2024}:
             self._move_holiday(dt)
 
-        if year >= 2022:
+        if self._year >= 2022:
             aug_31 = self._add_holiday_aug_31(
                 # Day of the Black Person and Afro-Costa Rican Culture.
                 self.tr("Día de la Persona Negra y la Cultura Afrocostarricense")
             )
-            if year in {2022, 2023}:
+            if self._year in {2022, 2023}:
                 # Move to next Sunday.
                 self._move_holiday(aug_31, rule=ALL_TO_NEXT_SUN)
 
         # Independence Day.
         sep_15 = self._add_holiday_sep_15(tr("Día de la Independencia"))
-        if year in {2020, 2021, 2022, 2024}:
+        if self._year in {2020, 2021, 2022, 2024}:
             self._move_holiday(sep_15)
 
-        if year <= 2019:
+        if self._year <= 2019:
             self._move_holiday(
                 # Cultures Day.
                 self._add_columbus_day(tr("Día de las Culturas")),
                 rule=WORKDAY_TO_NEXT_MON,
             )
 
-        if year >= 2020:
+        if self._year >= 2020:
             # Army Abolition Day.
             dec_1 = self._add_holiday_dec_1(tr("Día de la Abolición del Ejército"))
-            if year in {2020, 2021, 2022}:
+            if self._year in {2020, 2021, 2022}:
                 self._move_holiday(dec_1)
 
         # Christmas Day.

--- a/holidays/countries/croatia.py
+++ b/holidays/countries/croatia.py
@@ -32,34 +32,32 @@ class Croatia(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("Nova Godina"))
 
-        if year != 2002:
+        if self._year != 2002:
             # Epiphany.
             self._add_epiphany_day(tr("Bogojavljenje ili Sveta tri kralja"))
 
-        if year >= 2009:
+        if self._year >= 2009:
             # Easter.
             self._add_easter_sunday(tr("Uskrs"))
 
         # Easter Monday.
         self._add_easter_monday(tr("Uskrsni ponedjeljak"))
 
-        if year >= 2002:
+        if self._year >= 2002:
             # Corpus Christi.
             self._add_corpus_christi_day(tr("Tijelovo"))
 
         # International Workers' Day.
         self._add_labor_day(tr("Međunarodni praznik rada"))
 
-        if year >= 1996:
+        if self._year >= 1996:
             # Statehood Day.
             name = tr("Dan državnosti")
-            if 2002 <= year <= 2019:
+            if 2002 <= self._year <= 2019:
                 self._add_holiday_jun_25(name)
             else:
                 self._add_holiday_may_30(name)
@@ -70,7 +68,7 @@ class Croatia(HolidayBase, ChristianHolidays, InternationalHolidays):
         name = (
             # Victory and Homeland Thanksgiving Day and Croatian Veterans Day.
             tr("Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja")
-            if year >= 2008
+            if self._year >= 2008
             # Victory and Homeland Thanksgiving Day.
             else tr("Dan pobjede i domovinske zahvalnosti")
         )
@@ -79,14 +77,14 @@ class Croatia(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Assumption of Mary.
         self._add_assumption_of_mary_day(tr("Velika Gospa"))
 
-        if 2002 <= year <= 2019:
+        if 2002 <= self._year <= 2019:
             # Independence Day.
             self._add_holiday_oct_8(tr("Dan neovisnosti"))
 
         # All Saints' Day.
         self._add_all_saints_day(tr("Svi sveti"))
 
-        if year >= 2020:
+        if self._year >= 2020:
             # Memorial Day.
             self._add_holiday_nov_18(tr("Dan sjećanja"))
 

--- a/holidays/countries/cuba.py
+++ b/holidays/countries/cuba.py
@@ -42,20 +42,18 @@ class Cuba(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # This calendar only works from 1959 onwards.
-        if year <= 1958:
+        if self._year <= 1958:
             return None
-
-        super()._populate(year)
 
         # Liberation Day.
         jan_1 = self._add_holiday_jan_1(tr("Triunfo de la Revolución"))
-        if year <= 2013:
+        if self._year <= 2013:
             self._add_observed(jan_1)
 
         # Granted in 2007 decree.
-        if year >= 2008:
+        if self._year >= 2008:
             #  Victory Day.
             self._add_holiday_jan_2(tr("Día de la Victoria"))
 
@@ -63,7 +61,7 @@ class Cuba(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         #   https://cnn.it/3v5V6GY
         #   https://bit.ly/3v6bM18
         # Permanently granted in 2013 decree for 2014 and onwards.
-        if year >= 2012:
+        if self._year >= 2012:
             # Good Friday.
             self._add_good_friday(tr("Viernes Santo"))
 
@@ -90,12 +88,12 @@ class Cuba(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         # In 1998, Christmas returns for good:
         #   https://bit.ly/3cyXhwz
         #   https://bit.ly/3cyXj7F
-        if year <= 1968 or year >= 1997:
+        if self._year <= 1968 or self._year >= 1997:
             # Christmas Day.
             self._add_christmas_day(tr("Día de Navidad"))
 
         # Granted in 2007 decree.
-        if year >= 2007:
+        if self._year >= 2007:
             # New Year's Eve.
             self._add_new_years_eve(tr("Fiesta de Fin de Año"))
 

--- a/holidays/countries/curacao.py
+++ b/holidays/countries/curacao.py
@@ -36,12 +36,10 @@ class Curacao(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # 1954: Creation of the Netherlands Antilles.
-        if year <= 1953:
+        if self._year <= 1953:
             return None
-
-        super()._populate(year)
 
         # Aña Nobo.
         # Status: In-Use.
@@ -85,21 +83,21 @@ class Curacao(HolidayBase, ChristianHolidays, InternationalHolidays):
         name = (
             # King's Day.
             tr("Dia di Rey")
-            if year >= 2014
+            if self._year >= 2014
             # Queen's Day.
             else tr("Dia di la Reina")
         )
-        dt = date(year, APR, 27 if year >= 2014 else 30)
+        dt = date(self._year, APR, 27 if self._year >= 2014 else 30)
         if self._is_sunday(dt):
-            dt += td(days=-1 if year >= 1980 else +1)
+            dt += td(days=-1 if self._year >= 1980 else +1)
         self._add_holiday(name, dt)
 
         # Dia di Obrero.
         # Status: In-Use.
         # If fall on Sunday, then this will be move to next working day.
 
-        dt = date(year, MAY, 1)
-        if self._is_sunday(dt) or (self._is_monday(dt) and year <= 1979):
+        dt = date(self._year, MAY, 1)
+        if self._is_sunday(dt) or (self._is_monday(dt) and self._year <= 1979):
             dt += td(days=+1)
         # Labor Day
         self._add_holiday(tr("Dia di Obrero"), dt)
@@ -114,7 +112,7 @@ class Curacao(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Status: In-Use.
         # Starts in 1984.
 
-        if year >= 1984:
+        if self._year >= 1984:
             # National Anthem and Flag Day
             self._add_holiday_jul_2(tr("Dia di Himno i Bandera"))
 
@@ -122,7 +120,7 @@ class Curacao(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Status: In-Use.
         # Starts in 2010.
 
-        if year >= 2010:
+        if self._year >= 2010:
             # Curaçao Day
             self._add_holiday_oct_10(tr("Dia di Pais Kòrsou"))
 

--- a/holidays/countries/cyprus.py
+++ b/holidays/countries/cyprus.py
@@ -34,9 +34,7 @@ class Cyprus(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Years Day.
         self._add_new_years_day(tr("Πρωτοχρονιά"))
 

--- a/holidays/countries/czechia.py
+++ b/holidays/countries/czechia.py
@@ -29,58 +29,56 @@ class Czechia(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         self._add_holiday_jan_1(
             # Independent Czech State Restoration Day.
             tr("Den obnovy samostatného českého státu")
-            if year >= 2000
+            if self._year >= 2000
             # New Year's Day.
             else tr("Nový rok"),
         )
 
-        if year <= 1951 or year >= 2016:
+        if self._year <= 1951 or self._year >= 2016:
             # Good Friday.
             self._add_good_friday(tr("Velký pátek"))
 
         # Easter Monday.
         self._add_easter_monday(tr("Velikonoční pondělí"))
 
-        if year >= 1951:
+        if self._year >= 1951:
             # Labor Day.
             self._add_labor_day(tr("Svátek práce"))
 
-        if year >= 1992:
+        if self._year >= 1992:
             # Victory Day.
             self._add_holiday_may_8(tr("Den vítězství"))
-        elif year >= 1947:
+        elif self._year >= 1947:
             # Day of Victory over Fascism.
             self._add_world_war_two_victory_day(tr("Den vítězství nad hitlerovským fašismem"))
 
-        if year >= 1951:
+        if self._year >= 1951:
             # Saints Cyril and Methodius Day.
             self._add_holiday_jul_5(tr("Den slovanských věrozvěstů Cyrila a Metoděje"))
 
             # Jan Hus Day.
             self._add_holiday_jul_6(tr("Den upálení mistra Jana Husa"))
 
-        if year >= 2000:
+        if self._year >= 2000:
             # Statehood Day.
             self._add_holiday_sep_28(tr("Den české státnosti"))
 
-        if year >= 1951:
+        if self._year >= 1951:
             # Independent Czechoslovak State Day.
             self._add_holiday_oct_28(tr("Den vzniku samostatného československého státu"))
 
-        if year >= 1990:
+        if self._year >= 1990:
             # Struggle for Freedom and Democracy Day.
             self._add_holiday_nov_17(tr("Den boje za svobodu a demokracii"))
 
             # Christmas Eve.
             self._add_christmas_eve(tr("Štědrý den"))
 
-        if year >= 1951:
+        if self._year >= 1951:
             # Christmas Day.
             self._add_christmas_day(tr("1. svátek vánoční"))
 

--- a/holidays/countries/djibouti.py
+++ b/holidays/countries/djibouti.py
@@ -30,11 +30,10 @@ class Djibouti(HolidayBase, ChristianHolidays, IslamicHolidays, InternationalHol
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # On 27 June 1977, Djibouti gained independence from France.
-        if year <= 1977:
+        if self._year <= 1977:
             return None
-        super()._populate(year)
 
         # New Year's Day.
         self._add_new_years_day(tr("Nouvel an"))

--- a/holidays/countries/dominican_republic.py
+++ b/holidays/countries/dominican_republic.py
@@ -42,9 +42,7 @@ class DominicanRepublic(ObservedHolidayBase, ChristianHolidays, InternationalHol
         # Law No. 139-97 - Holidays Dominican Republic - Jun 27, 1997
         return dt >= date(1997, JUN, 27)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("Año Nuevo"))
 
@@ -75,7 +73,7 @@ class DominicanRepublic(ObservedHolidayBase, ChristianHolidays, InternationalHol
         # Restoration Day.
         name = tr("Día de la Restauración")
         # Judgment No. 14 of Feb 20, 2008 of the Supreme Court of Justice
-        if year <= 2007 and year % 4 == 0:
+        if self._year <= 2007 and self._year % 4 == 0:
             self._add_holiday_aug_16(name)
         else:
             self._move_holiday(self._add_holiday_aug_16(name))

--- a/holidays/countries/ecuador.py
+++ b/holidays/countries/ecuador.py
@@ -54,9 +54,7 @@ class Ecuador(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         kwargs.setdefault("observed_since", 2017)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         name = self.tr("Año Nuevo")
         self._add_observed(self._add_new_years_day(name), rule=SAT_TO_PREV_FRI + SUN_TO_NEXT_MON)

--- a/holidays/countries/egypt.py
+++ b/holidays/countries/egypt.py
@@ -44,19 +44,17 @@ class Egypt(HolidayBase, ChristianHolidays, IslamicHolidays, InternationalHolida
 
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day
         self._add_new_years_day(tr("رأس السنة الميلادية"))
 
         # Coptic Christmas
         self._add_christmas_day(tr("عيد الميلاد المجيد (تقويم قبطي)"))
 
-        if year >= 2012:
+        if self._year >= 2012:
             # January 25th Revolution
             self._add_holiday_jan_25(tr("عيد ثورة 25 يناير"))
-        elif year >= 2009:
+        elif self._year >= 2009:
             # National Police Day
             self._add_holiday_jan_25(tr("عيد الشرطة"))
 
@@ -64,7 +62,7 @@ class Egypt(HolidayBase, ChristianHolidays, IslamicHolidays, InternationalHolida
         self._add_easter_sunday(tr("عيد الفصح القبطي"))
         self._add_easter_monday(tr("شم النسيم"))  # Spring Festival
 
-        if year > 1982:
+        if self._year > 1982:
             # Sinai Libration Day
             self._add_holiday_apr_25(tr("عيد تحرير سيناء"))
 
@@ -74,11 +72,11 @@ class Egypt(HolidayBase, ChristianHolidays, IslamicHolidays, InternationalHolida
         # Armed Forces Day
         self._add_holiday_oct_6(tr("عيد القوات المسلحة"))
 
-        if year >= 2014:
+        if self._year >= 2014:
             # June 30 Revolution Day
             self._add_holiday_jun_30(tr("عيد ثورة 30 يونيو"))
 
-        if year > 1952:
+        if self._year > 1952:
             # July 23 Revolution Day
             self._add_holiday_jul_23(tr("عيد ثورة 23 يوليو"))
 

--- a/holidays/countries/el_salvador.py
+++ b/holidays/countries/el_salvador.py
@@ -44,9 +44,7 @@ class ElSalvador(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day("New Year's Day")
 
@@ -62,12 +60,12 @@ class ElSalvador(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Labor Day.
         self._add_labor_day("Labor Day")
 
-        if year >= 2016:
+        if self._year >= 2016:
             # Legislative Decree #399 from Apr 14, 2016
             # Mothers' Day.
             self._add_holiday_may_10("Mothers' Day")
 
-        if year >= 2013:
+        if self._year >= 2013:
             # Legislative Decree #208 from Jun 17, 2012
             # Fathers' Day.
             self._add_holiday_jun_17("Fathers' Day")

--- a/holidays/countries/estonia.py
+++ b/holidays/countries/estonia.py
@@ -25,9 +25,7 @@ class Estonia(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("uusaasta"))
 
@@ -52,11 +50,11 @@ class Estonia(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Midsummer Day.
         self._add_saint_johns_day(tr("jaanipäev"))
 
-        if year >= 1998:
+        if self._year >= 1998:
             # Independence Restoration Day.
             self._add_holiday_aug_20(tr("taasiseseisvumispäev"))
 
-        if year >= 2005:
+        if self._year >= 2005:
             # Christmas Eve.
             self._add_christmas_eve(tr("jõululaupäev"))
 

--- a/holidays/countries/eswatini.py
+++ b/holidays/countries/eswatini.py
@@ -33,12 +33,10 @@ class Eswatini(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, St
         kwargs.setdefault("observed_since", 2021)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # Observed since 1939
-        if year <= 1938:
+        if self._year <= 1938:
             return None
-
-        super()._populate(year)
 
         self._add_observed(self._add_new_years_day("New Year's Day"))
 
@@ -48,13 +46,13 @@ class Eswatini(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, St
 
         self._add_ascension_thursday("Ascension Day")
 
-        if year >= 1987:
+        if self._year >= 1987:
             self._add_observed(
                 apr_19 := self._add_holiday_apr_19("King's Birthday"),
                 rule=SUN_TO_NEXT_TUE if apr_19 == self._easter_sunday else SUN_TO_NEXT_MON,
             )
 
-        if year >= 1969:
+        if self._year >= 1969:
             self._add_observed(
                 apr_25 := self._add_holiday_apr_25("National Flag Day"),
                 rule=SUN_TO_NEXT_TUE if apr_25 == self._easter_sunday else SUN_TO_NEXT_MON,
@@ -62,7 +60,7 @@ class Eswatini(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, St
 
         self._add_observed(self._add_labor_day("Worker's Day"))
 
-        if year >= 1983:
+        if self._year >= 1983:
             self._add_observed(self._add_holiday_jul_22("Birthday of Late King Sobhuza"))
 
         self._add_observed(self._add_holiday_sep_6("Independence Day"))

--- a/holidays/countries/ethiopia.py
+++ b/holidays/countries/ethiopia.py
@@ -17,19 +17,6 @@ from holidays.calendars.julian import JULIAN_CALENDAR
 from holidays.groups import ChristianHolidays, InternationalHolidays, IslamicHolidays
 from holidays.holiday_base import HolidayBase
 
-# Ethiopian holidays are estimated: it is common for the day to be pushed
-# if falls in a weekend, although not a rule that can be implemented.
-# Holidays after 2020: the following four moving date holidays whose exact
-# date is announced yearly are estimated (and so denoted):
-# - Eid El Fetr*
-# - Eid El Adha*
-# - Arafat Day*
-# - Moulad El Naby*
-# *only if hijri-converter library is installed, otherwise a warning is
-#  raised that this holiday is missing. hijri-converter requires
-#  Python >= 3.6
-# is_weekend function is there, however not activated for accuracy.
-
 
 class Ethiopia(HolidayBase, ChristianHolidays, InternationalHolidays, IslamicHolidays):
     country = "ET"
@@ -55,9 +42,7 @@ class Ethiopia(HolidayBase, ChristianHolidays, InternationalHolidays, IslamicHol
         IslamicHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day
         # The Ethiopian New Year is called Kudus Yohannes in Ge'ez and
         # Tigrinya, while in Amharic,
@@ -84,22 +69,22 @@ class Ethiopia(HolidayBase, ChristianHolidays, InternationalHolidays, IslamicHol
         # Orthodox Easter Sunday.
         self._add_easter_sunday(tr("ፋሲካ"))
 
-        if year > 1896:
+        if self._year > 1896:
             # Adwa Victory Day.
             self._add_holiday_mar_2(tr("አድዋ"))
 
         # Labour Day.
         self._add_labor_day(tr("የሰራተኞች ቀን"))
 
-        if year > 1941:
+        if self._year > 1941:
             # Patriots Day.
             self._add_holiday_may_5(tr("የአርበኞች ቀን"))
 
-        if year > 1991:
+        if self._year > 1991:
             # Downfall of Dergue Regime Day.
             self._add_holiday_may_28(tr("ደርግ የወደቀበት ቀን"))
 
-        if year < 1991 and year > 1974:
+        if self._year < 1991 and self._year > 1974:
             # Downfall of King Haile Selassie.
             self._add_holiday(tr("ደርግ የመጣበት ቀን"), SEP, 13 if self._is_leap_year() else 12)
 

--- a/holidays/countries/finland.py
+++ b/holidays/countries/finland.py
@@ -30,15 +30,13 @@ class Finland(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("Uudenvuodenpäivä"))
 
         # Epiphany.
         name = tr("Loppiainen")
-        if 1973 <= year <= 1990:
+        if 1973 <= self._year <= 1990:
             self._add_holiday_1st_sat_from_jan_6(name)
         else:
             self._add_epiphany_day(name)
@@ -57,7 +55,7 @@ class Finland(HolidayBase, ChristianHolidays, InternationalHolidays):
 
         # Ascension Day.
         name = tr("Helatorstai")
-        if 1973 <= year <= 1990:
+        if 1973 <= self._year <= 1990:
             self._add_holiday(name, self._easter_sunday + td(days=+34))
         else:
             self._add_ascension_thursday(name)
@@ -67,7 +65,7 @@ class Finland(HolidayBase, ChristianHolidays, InternationalHolidays):
 
         # Midsummer Eve.
         name = tr("Juhannusaatto")
-        if year >= 1955:
+        if self._year >= 1955:
             dt = self._add_holiday_1st_fri_from_jun_19(name)
         else:
             dt = self._add_holiday_jun_23(name)
@@ -77,7 +75,7 @@ class Finland(HolidayBase, ChristianHolidays, InternationalHolidays):
 
         # All Saints' Day.
         name = tr("Pyhäinpäivä")
-        if year >= 1955:
+        if self._year >= 1955:
             self._add_holiday_1st_sat_from_oct_31(name)
         else:
             self._add_holiday_nov_1(name)

--- a/holidays/countries/france.py
+++ b/holidays/countries/france.py
@@ -68,46 +68,44 @@ class France(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # Civil holidays.
-        if year >= 1811:
+        if self._year >= 1811:
             # New Year's Day.
             self._add_new_years_day(tr("Jour de l'an"))
 
-        if year >= 1919:
+        if self._year >= 1919:
             self._add_labor_day(
                 # Labor Day.
                 tr("Fête du Travail")
-                if year >= 1948
+                if self._year >= 1948
                 # Labor and Social Concord Day.
                 else tr("Fête du Travail et de la Concorde sociale")
             )
 
-        if 1953 <= year <= 1959 or year >= 1982:
+        if 1953 <= self._year <= 1959 or self._year >= 1982:
             # Victory Day.
             self._add_holiday_may_8(tr("Fête de la Victoire"))
 
-        if year >= 1880:
+        if self._year >= 1880:
             # National Day.
             self._add_holiday_jul_14(tr("Fête nationale"))
 
-        if year >= 1918:
+        if self._year >= 1918:
             # Armistice Day.
             self._add_holiday_nov_11(tr("Armistice"))
 
         # Religious holidays.
 
-        if year >= 1886:
+        if self._year >= 1886:
             # Easter Monday.
             self._add_easter_monday(tr("Lundi de Pâques"))
 
-            if year not in {2005, 2006, 2007}:
+            if self._year not in {2005, 2006, 2007}:
                 # Whit Monday.
                 self._add_whit_monday(tr("Lundi de Pentecôte"))
 
-        if year >= 1802:
+        if self._year >= 1802:
             # Ascension Day.
             self._add_ascension_thursday(tr("Ascension"))
             # Assumption Day.

--- a/holidays/countries/gabon.py
+++ b/holidays/countries/gabon.py
@@ -32,12 +32,10 @@ class Gabon(HolidayBase, ChristianHolidays, InternationalHolidays, IslamicHolida
         IslamicHolidays.__init__(self, cls=GabonIslamicHolidays)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # On 17 August 1960, Gabon gained independence from France.
-        if year <= 1960:
+        if self._year <= 1960:
             return None
-
-        super()._populate(year)
 
         # New Year's Day.
         self._add_new_years_day("New Year's Day")
@@ -46,7 +44,7 @@ class Gabon(HolidayBase, ChristianHolidays, InternationalHolidays, IslamicHolida
         self._add_easter_monday("Easter Monday")
 
         # Women's Rights Day.
-        if year >= 2015:
+        if self._year >= 2015:
             self._add_holiday_apr_17("Women's Rights Day")
 
         # Labour Day.

--- a/holidays/countries/georgia.py
+++ b/holidays/countries/georgia.py
@@ -34,10 +34,9 @@ class Georgia(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1990:
+    def _populate_public_holidays(self):
+        if self._year <= 1990:
             return None
-        super()._populate(year)
 
         # New Year's Day.
         name = tr("ახალი წელი")

--- a/holidays/countries/germany.py
+++ b/holidays/countries/germany.py
@@ -78,13 +78,11 @@ class Germany(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1989:
+    def _populate_public_holidays(self):
+        if self._year <= 1989:
             return None
 
-        super()._populate(year)
-
-        if year >= 1991:
+        if self._year >= 1991:
             # New Year's Day.
             self._add_new_years_day(tr("Neujahr"))
 
@@ -106,11 +104,11 @@ class Germany(HolidayBase, ChristianHolidays, InternationalHolidays):
         # German Unity Day.
         self._add_holiday_oct_3(tr("Tag der Deutschen Einheit"))
 
-        if year == 2017:
+        if self._year == 2017:
             # Reformation Day.
             self._add_holiday_oct_31(tr("Reformationstag"))
 
-        if year <= 1994:
+        if self._year <= 1994:
             # Repentance and Prayer Day.
             self._add_holiday_1st_wed_before_nov_22(tr("Buß- und Bettag"))
 
@@ -121,6 +119,9 @@ class Germany(HolidayBase, ChristianHolidays, InternationalHolidays):
         self._add_christmas_day_two(tr("Zweiter Weihnachtstag"))
 
     def _populate_subdiv_bb_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 1991:
             # Easter Sunday.
             self._add_easter_sunday(tr("Ostersonntag"))
@@ -132,6 +133,9 @@ class Germany(HolidayBase, ChristianHolidays, InternationalHolidays):
             self._add_holiday_oct_31(tr("Reformationstag"))
 
     def _populate_subdiv_be_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 2019:
             # International Women's Day.
             self._add_womens_day(tr("Internationaler Frauentag"))
@@ -147,6 +151,9 @@ class Germany(HolidayBase, ChristianHolidays, InternationalHolidays):
             )
 
     def _populate_subdiv_bw_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 1991:
             # Epiphany.
             self._add_epiphany_day(tr("Heilige Drei Könige"))
@@ -158,6 +165,9 @@ class Germany(HolidayBase, ChristianHolidays, InternationalHolidays):
         self._add_all_saints_day(tr("Allerheiligen"))
 
     def _populate_subdiv_by_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 1991:
             self._add_epiphany_day(tr("Heilige Drei Könige"))
             self._add_corpus_christi_day(tr("Fronleichnam"))
@@ -168,6 +178,9 @@ class Germany(HolidayBase, ChristianHolidays, InternationalHolidays):
         self._add_all_saints_day(tr("Allerheiligen"))
 
     def _populate_subdiv_byp_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 1991:
             self._add_epiphany_day(tr("Heilige Drei Könige"))
             self._add_corpus_christi_day(tr("Fronleichnam"))
@@ -175,18 +188,30 @@ class Germany(HolidayBase, ChristianHolidays, InternationalHolidays):
         self._add_all_saints_day(tr("Allerheiligen"))
 
     def _populate_subdiv_hb_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 2018:
             self._add_holiday_oct_31(tr("Reformationstag"))
 
     def _populate_subdiv_he_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 1991:
             self._add_corpus_christi_day(tr("Fronleichnam"))
 
     def _populate_subdiv_hh_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 2018:
             self._add_holiday_oct_31(tr("Reformationstag"))
 
     def _populate_subdiv_mv_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 2023:
             self._add_womens_day(tr("Internationaler Frauentag"))
 
@@ -194,26 +219,41 @@ class Germany(HolidayBase, ChristianHolidays, InternationalHolidays):
             self._add_holiday_oct_31(tr("Reformationstag"))
 
     def _populate_subdiv_ni_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 2018:
             self._add_holiday_oct_31(tr("Reformationstag"))
 
     def _populate_subdiv_nw_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 1991:
             self._add_corpus_christi_day(tr("Fronleichnam"))
 
         self._add_all_saints_day(tr("Allerheiligen"))
 
     def _populate_subdiv_rp_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 1991:
             self._add_corpus_christi_day(tr("Fronleichnam"))
 
         self._add_all_saints_day(tr("Allerheiligen"))
 
     def _populate_subdiv_sh_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 2018:
             self._add_holiday_oct_31(tr("Reformationstag"))
 
     def _populate_subdiv_sl_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 1991:
             self._add_corpus_christi_day(tr("Fronleichnam"))
             self._add_assumption_of_mary_day(tr("Mariä Himmelfahrt"))
@@ -221,6 +261,9 @@ class Germany(HolidayBase, ChristianHolidays, InternationalHolidays):
         self._add_all_saints_day(tr("Allerheiligen"))
 
     def _populate_subdiv_sn_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year != 2017:
             self._add_holiday_oct_31(tr("Reformationstag"))
 
@@ -229,6 +272,9 @@ class Germany(HolidayBase, ChristianHolidays, InternationalHolidays):
             self._add_holiday_1st_wed_before_nov_22(tr("Buß- und Bettag"))
 
     def _populate_subdiv_st_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 1991:
             self._add_epiphany_day(tr("Heilige Drei Könige"))
 
@@ -236,6 +282,9 @@ class Germany(HolidayBase, ChristianHolidays, InternationalHolidays):
             self._add_holiday_oct_31(tr("Reformationstag"))
 
     def _populate_subdiv_th_public_holidays(self):
+        if self._year <= 1989:
+            return None
+
         if self._year >= 2019:
             # World Children's Day.
             self._add_holiday_sep_20(tr("Weltkindertag"))

--- a/holidays/countries/guam.py
+++ b/holidays/countries/guam.py
@@ -20,9 +20,8 @@ class HolidaysGU(US):
     country = "GU"
     subdivisions = ()  # Override US subdivisions.
 
-    def _populate(self, year: int) -> None:
+    def _populate_public_holidays(self) -> None:
         self.subdiv = "GU"
-        super()._populate(year)
 
 
 class GU(HolidaysGU):

--- a/holidays/countries/guatemala.py
+++ b/holidays/countries/guatemala.py
@@ -44,9 +44,7 @@ class Guatemala(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
     def _is_observed(self, dt: date) -> bool:
         return dt >= date(2018, OCT, 18)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("Año Nuevo"))
 
@@ -61,7 +59,7 @@ class Guatemala(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
 
         # Labor Day.
         dt = self._add_labor_day(tr("Dia del Trabajo"))
-        if year == 2019:
+        if self._year == 2019:
             self._move_holiday(dt)
 
         # Army Day.
@@ -75,7 +73,7 @@ class Guatemala(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
 
         # Revolution Day
         dt = self._add_holiday_oct_20(tr("Dia de la Revolución"))
-        if year in {2018, 2019}:
+        if self._year in {2018, 2019}:
             self._move_holiday(dt)
 
         # All Saints' Day.

--- a/holidays/countries/honduras.py
+++ b/holidays/countries/honduras.py
@@ -29,9 +29,7 @@ class Honduras(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("Año Nuevo"))
 
@@ -54,7 +52,7 @@ class Honduras(HolidayBase, ChristianHolidays, InternationalHolidays):
         self._add_holiday_sep_15(tr("Día de la Independencia"))
 
         # https://www.tsc.gob.hn/web/leyes/Decreto_78-2015_Traslado_de_Feriados_Octubre.pdf
-        if year <= 2014:
+        if self._year <= 2014:
             # Morazan's Day.
             self._add_holiday_oct_3(tr("Día de Morazán"))
 

--- a/holidays/countries/hongkong.py
+++ b/holidays/countries/hongkong.py
@@ -64,12 +64,11 @@ class HongKong(
         is_obs, dt_observed = self._add_observed(dt, name=name, rule=rule)
         return dt_observed if is_obs else super()._add_holiday(name, dt)  # type: ignore[arg-type]
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # Current set of holidays actually valid since 1946
-        if year <= 1945:
+        if self._year <= 1945:
             return None
 
-        super()._populate(year)
         self.weekend = {SUN}
 
         # The first day of January
@@ -84,7 +83,7 @@ class HongKong(
         dt_lunar_new_year = self._chinese_new_year
         if self.observed:
             if self._is_sunday(dt_lunar_new_year):
-                if year in {2006, 2007, 2010}:
+                if self._year in {2006, 2007, 2010}:
                     self._add_chinese_new_years_eve(preceding_day_lunar)
                 else:
                     self._add_chinese_new_years_day_four(fourth_day_lunar)
@@ -127,7 +126,7 @@ class HongKong(
         }:
             super()._add_holiday(name, dt_qingming)
 
-        if year >= 1999:
+        if self._year >= 1999:
             # The Birthday of the Buddha
             self._add_chinese_birthday_of_buddha("The Birthday of the Buddha")
 
@@ -138,7 +137,7 @@ class HongKong(
         self._add_dragon_boat_festival("Tuen Ng Festival")
 
         # Hong Kong Special Administrative Region Establishment Day
-        if year >= 1997:
+        if self._year >= 1997:
             self._add_holiday_jul_1("Hong Kong Special Administrative Region Establishment Day")
 
         # Chinese Mid-Autumn Festival
@@ -150,7 +149,7 @@ class HongKong(
             # from 1983 to 2010 public holiday lies on same day
             # since 2011 public holiday lies on Monday
             if self._is_saturday(mid_autumn_date):
-                if 1983 <= year <= 2010:
+                if 1983 <= self._year <= 2010:
                     self._add_mid_autumn_festival(name)
                 else:
                     self._add_holiday(
@@ -165,10 +164,10 @@ class HongKong(
         self._add_double_ninth_festival("Chung Yeung Festival")
 
         # National Day
-        if year >= 1997:
+        if self._year >= 1997:
             self._add_holiday_oct_1("National Day")
 
-            if year <= 1998:
+            if self._year <= 1998:
                 self._add_holiday_oct_2("National Day")
 
         # Christmas Day
@@ -191,15 +190,15 @@ class HongKong(
             self._add_christmas_day_two(first_after_christmas)
 
         # Previous holidays
-        if 1952 <= year <= 1997:
+        if 1952 <= self._year <= 1997:
             # Queen's Birthday (June 2nd Monday)
             self._add_holiday_2nd_mon_of_jun("Queen's Birthday")
 
-        if year <= 1996:
+        if self._year <= 1996:
             # Anniversary of the liberation of Hong Kong (August last Monday)
             self._add_holiday_last_mon_of_aug("Anniversary of the liberation of Hong Kong")
 
-        if year <= 1998:
+        if self._year <= 1998:
             # Anniversary of the victory in the Second Sino-Japanese War
             super()._add_holiday(
                 "Anniversary of the victory in the Second Sino-Japanese War",

--- a/holidays/countries/hungary.py
+++ b/holidays/countries/hungary.py
@@ -50,74 +50,72 @@ class Hungary(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolid
         StaticHolidays.__init__(self, HungaryStaticHolidays)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(self.tr("Újév"))
 
-        if 1945 <= year <= 1950 or year >= 1989:
+        if 1945 <= self._year <= 1950 or self._year >= 1989:
             # National Day.
             self._add_holiday_mar_15(tr("Nemzeti ünnep"))
 
-        if year >= 2017:
+        if self._year >= 2017:
             # Good Friday.
             self._add_good_friday(tr("Nagypéntek"))
 
         # Easter.
         self._add_easter_sunday(tr("Húsvét"))
 
-        if year != 1955:
+        if self._year != 1955:
             # Easter Monday.
             self._add_easter_monday(tr("Húsvét Hétfő"))
 
         # Whit Sunday.
         self._add_whit_sunday(tr("Pünkösd"))
 
-        if year <= 1952 or year >= 1992:
+        if self._year <= 1952 or self._year >= 1992:
             # Whit Monday.
             self._add_whit_monday(tr("Pünkösdhétfő"))
 
-        if year >= 1946:
+        if self._year >= 1946:
             # Labor Day.
             name = tr("A Munka ünnepe")
             self._add_labor_day(name)
-            if 1950 <= year <= 1953:
+            if 1950 <= self._year <= 1953:
                 self._add_labor_day_two(name)
 
         self._add_holiday_aug_20(
             # Bread Day.
             tr("A kenyér ünnepe")
-            if 1950 <= year <= 1989
+            if 1950 <= self._year <= 1989
             else
             # State Foundation Day.
             tr("Az államalapítás ünnepe"),
         )
 
-        if year >= 1991:
+        if self._year >= 1991:
             # National Day.
             self._add_holiday_oct_23(tr("Nemzeti ünnep"))
 
-        if year >= 1999:
+        if self._year >= 1999:
             # All Saints' Day.
             self._add_all_saints_day(tr("Mindenszentek"))
 
         # Christmas Day.
         self._add_christmas_day(tr("Karácsony"))
 
-        if year != 1955:
+        if self._year != 1955:
             # Second Day of Christmas.
             self._add_christmas_day_two(tr("Karácsony másnapja"))
 
         # Soviet era.
-        if 1950 <= year <= 1989:
+        if 1950 <= self._year <= 1989:
             # Proclamation of Soviet Republic Day.
             self._add_holiday_mar_21(tr("A Tanácsköztársaság kikiáltásának ünnepe"))
 
             # Liberation Day.
             self._add_holiday_apr_4(tr("A felszabadulás ünnepe"))
 
-            if year not in {1956, 1989}:
+            if self._year not in {1956, 1989}:
                 # Great October Socialist Revolution Day.
                 self._add_holiday_nov_7(tr("A nagy októberi szocialista forradalom ünnepe"))
 

--- a/holidays/countries/iceland.py
+++ b/holidays/countries/iceland.py
@@ -30,9 +30,7 @@ class Iceland(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("Nýársdagur"))
 

--- a/holidays/countries/india.py
+++ b/holidays/countries/india.py
@@ -73,17 +73,15 @@ class India(HolidayBase, ChristianHolidays, InternationalHolidays, IslamicHolida
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # Makar Sankranti / Pongal.
         self._add_holiday_jan_14("Makar Sankranti / Pongal")
 
-        if year >= 1950:
+        if self._year >= 1950:
             # Republic Day.
             self._add_holiday_jan_26("Republic Day")
 
-        if year >= 1947:
+        if self._year >= 1947:
             # Independence Day.
             self._add_holiday_aug_15("Independence Day")
 
@@ -96,7 +94,7 @@ class India(HolidayBase, ChristianHolidays, InternationalHolidays, IslamicHolida
         # Directly lifted Diwali and Holi dates from FBProphet from:
         # https://github.com/facebook/prophet/blob/main/python/prophet/hdays.py
         # Warnings kept in place so that users are aware
-        if year < 2001 or year > 2030:
+        if self._year < 2001 or self._year > 2030:
             warning_msg = "Diwali and Holi holidays available from 2001 to 2030 only"
             warnings.warn(warning_msg, Warning)
 
@@ -168,11 +166,11 @@ class India(HolidayBase, ChristianHolidays, InternationalHolidays, IslamicHolida
             2030: (MAR, 20),
         }
 
-        if year in diwali_dates:
-            self._add_holiday("Diwali", diwali_dates[year])
+        if self._year in diwali_dates:
+            self._add_holiday("Diwali", diwali_dates[self._year])
 
-        if year in holi_dates:
-            self._add_holiday("Holi", holi_dates[year])
+        if self._year in holi_dates:
+            self._add_holiday("Holi", holi_dates[self._year])
 
         # Islamic holidays.
         # Day of Ashura.

--- a/holidays/countries/iran.py
+++ b/holidays/countries/iran.py
@@ -33,11 +33,9 @@ class Iran(HolidayBase, IslamicHolidays, PersianCalendarHolidays):
         PersianCalendarHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1979:
+    def _populate_public_holidays(self):
+        if self._year <= 1979:
             return None
-
-        super()._populate(year)
 
         # Persian New Year.
         name = tr("نوروز")

--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -35,14 +35,12 @@ class Ireland(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Sta
         kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day("New Year's Day")
 
         # St. Brigid's Day.
-        if year >= 2023:
+        if self._year >= 2023:
             name = "St. Brigid's Day"
             if self._is_friday(FEB, 1):
                 self._add_holiday_feb_1(name)
@@ -56,9 +54,9 @@ class Ireland(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Sta
         self._add_easter_monday("Easter Monday")
 
         # May Day.
-        if year >= 1978:
+        if self._year >= 1978:
             name = "May Day"
-            if year == 1995:
+            if self._year == 1995:
                 self._add_holiday_may_8(name)
             else:
                 self._add_holiday_1st_mon_of_may(name)

--- a/holidays/countries/isle_of_man.py
+++ b/holidays/countries/isle_of_man.py
@@ -30,14 +30,13 @@ class IsleOfMan(UnitedKingdom):
         kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
         ObservedHolidayBase.__init__(self, *args, **kwargs)
 
-    def _populate(self, year: int) -> None:
-        super()._populate(year)
-
+    def _populate_public_holidays(self) -> None:
+        super()._populate_public_holidays()
         # Easter Monday
         self._add_easter_monday("Easter Monday")
 
         # Late Summer bank holiday (last Monday in August)
-        if year >= 1971:
+        if self._year >= 1971:
             self._add_holiday_last_mon_of_aug("Late Summer Bank Holiday")
 
         # Isle of Man exclusive holidays
@@ -46,9 +45,10 @@ class IsleOfMan(UnitedKingdom):
 
         # Tynwald Day
         # Move to the next Monday if falls on a weekend.
-        dt = date(year, JUL, 5)
+        dt = date(self._year, JUL, 5)
         self._add_holiday(
-            "Tynwald Day", self._get_observed_date(dt, SAT_SUN_TO_NEXT_MON) if year >= 1992 else dt
+            "Tynwald Day",
+            self._get_observed_date(dt, SAT_SUN_TO_NEXT_MON) if self._year >= 1992 else dt,
         )
 
 

--- a/holidays/countries/italy.py
+++ b/holidays/countries/italy.py
@@ -152,9 +152,7 @@ class Italy(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day("Capodanno")
 
@@ -167,14 +165,14 @@ class Italy(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Easter Monday.
         self._add_easter_monday("Lunedì dell'Angelo")
 
-        if year >= 1946:
+        if self._year >= 1946:
             # Liberation Day.
             self._add_holiday_apr_25("Festa della Liberazione")
 
         # Labor Day.
         self._add_labor_day("Festa dei Lavoratori")
 
-        if year >= 1948:
+        if self._year >= 1948:
             # Republic Day.
             self._add_holiday_jun_2("Festa della Repubblica")
 

--- a/holidays/countries/jamaica.py
+++ b/holidays/countries/jamaica.py
@@ -33,9 +33,7 @@ class Jamaica(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day
         self._add_observed(self._add_new_years_day("New Year's Day"))
 
@@ -54,7 +52,7 @@ class Jamaica(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         )
 
         # Emancipation Day
-        if year >= 1998:
+        if self._year >= 1998:
             self._add_observed(self._add_holiday_aug_1("Emancipation Day"))
 
         # Independence Day

--- a/holidays/countries/kazakhstan.py
+++ b/holidays/countries/kazakhstan.py
@@ -34,12 +34,11 @@ class Kazakhstan(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, 
         kwargs.setdefault("observed_since", 2002)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # Kazakhstan declared its sovereignty on 25 October 1990
-        if year <= 1990:
+        if self._year <= 1990:
             return None
 
-        super()._populate(year)
         dts_observed = set()
 
         # New Year's holiday (2 days)
@@ -48,17 +47,17 @@ class Kazakhstan(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, 
         dts_observed.add(self._add_new_years_day_two(name))
 
         # Orthodox Christmas (nonworking day, without extending)
-        if year >= 2006:
+        if self._year >= 2006:
             self._add_christmas_day("Orthodox Christmas")
 
         # International Women's Day
         dts_observed.add(self._add_womens_day("International Women's Day"))
 
         # Nauryz holiday
-        if year >= 2002:
+        if self._year >= 2002:
             name = "Nauryz holiday"
             dts_observed.add(self._add_holiday_mar_22(name))
-            if year >= 2010:
+            if self._year >= 2010:
                 dts_observed.add(self._add_holiday_mar_21(name))
                 dts_observed.add(self._add_holiday_mar_23(name))
 
@@ -66,41 +65,41 @@ class Kazakhstan(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, 
         dts_observed.add(self._add_labor_day("Kazakhstan People Solidarity Holiday"))
 
         # Defender of the Fatherland Day
-        if year >= 2013:
+        if self._year >= 2013:
             dts_observed.add(self._add_holiday_may_7("Defender of the Fatherland Day"))
 
         # Victory Day
         dts_observed.add(self._add_world_war_two_victory_day("Victory Day"))
 
         # Capital Day
-        if year >= 2009:
+        if self._year >= 2009:
             dts_observed.add(self._add_holiday_jul_6("Capital Day"))
 
         # Constitution Day of the Republic of Kazakhstan
-        if year >= 1996:
+        if self._year >= 1996:
             dts_observed.add(
                 self._add_holiday_aug_30("Constitution Day of the Republic of Kazakhstan")
             )
 
         # Republic Day
-        if 1994 <= year <= 2008 or year >= 2022:
+        if 1994 <= self._year <= 2008 or self._year >= 2022:
             dts_observed.add(self._add_holiday_oct_25("Republic Day"))
 
         # First President Day
-        if 2012 <= year <= 2021:
+        if 2012 <= self._year <= 2021:
             dts_observed.add(self._add_holiday_dec_1("First President Day"))
 
         # Kazakhstan Independence Day
         name = "Kazakhstan Independence Day"
         dts_observed.add(self._add_holiday_dec_16(name))
-        if 2002 <= year <= 2021:
+        if 2002 <= self._year <= 2021:
             dts_observed.add(self._add_holiday_dec_17(name))
 
         if self.observed:
             self._populate_observed(dts_observed)
 
         # Kurban Ait (nonworking day, without extending)
-        if year >= 2006:
+        if self._year >= 2006:
             self._add_eid_al_adha_day("Kurban Ait")
 
 

--- a/holidays/countries/kenya.py
+++ b/holidays/countries/kenya.py
@@ -31,11 +31,9 @@ class Kenya(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1962:
+    def _populate_public_holidays(self):
+        if self._year <= 1962:
             return None
-
-        super()._populate(year)
 
         # New Year's Day
         self._add_observed(self._add_new_years_day("New Year's Day"))
@@ -49,19 +47,19 @@ class Kenya(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stati
         # Labour Day
         self._add_observed(self._add_labor_day("Labour Day"))
 
-        if year >= 2010:
+        if self._year >= 2010:
             # Mandaraka Day
             self._add_observed(self._add_holiday_jun_1("Madaraka Day"))
 
-        if 2002 <= year <= 2009 or year >= 2018:
+        if 2002 <= self._year <= 2009 or self._year >= 2018:
             self._add_observed(
                 # Utamaduni/Moi Day
-                self._add_holiday_oct_10("Utamaduni Day" if year >= 2021 else "Moi Day")
+                self._add_holiday_oct_10("Utamaduni Day" if self._year >= 2021 else "Moi Day")
             )
 
         self._add_observed(
             # Mashuja/Kenyatta Day
-            self._add_holiday_oct_20("Mashujaa Day" if year >= 2010 else "Kenyatta Day")
+            self._add_holiday_oct_20("Mashujaa Day" if self._year >= 2010 else "Kenyatta Day")
         )
 
         # Jamhuri Day

--- a/holidays/countries/kyrgyzstan.py
+++ b/holidays/countries/kyrgyzstan.py
@@ -30,9 +30,7 @@ class Kyrgyzstan(HolidayBase, ChristianHolidays, InternationalHolidays, IslamicH
         IslamicHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day("New Year's Day")
 
@@ -48,7 +46,7 @@ class Kyrgyzstan(HolidayBase, ChristianHolidays, InternationalHolidays, IslamicH
         # Nooruz Mairamy.
         self._add_holiday_mar_21("Nooruz Mairamy")
 
-        if year >= 2016:
+        if self._year >= 2016:
             # Day of the People's April Revolution.
             self._add_holiday_apr_7("Day of the People's April Revolution")
 

--- a/holidays/countries/latvia.py
+++ b/holidays/countries/latvia.py
@@ -37,10 +37,9 @@ class Latvia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1989:
+    def _populate_public_holidays(self):
+        if self._year <= 1989:
             return None
-        super()._populate(year)
 
         # New Year's Day.
         self._add_new_years_day(tr("Jaunais Gads"))
@@ -57,12 +56,12 @@ class Latvia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         # Labor Day.
         self._add_labor_day(tr("Darba svētki"))
 
-        if year >= 2002:
+        if self._year >= 2002:
             dt = self._add_holiday_may_4(
                 # Restoration of Independence Day.
                 tr("Latvijas Republikas Neatkarības atjaunošanas diena")
             )
-            if year >= 2008:
+            if self._year >= 2008:
                 self._add_observed(dt)
 
         # Mother's Day.
@@ -76,10 +75,10 @@ class Latvia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
 
         # Republic of Latvia Proclamation Day.
         dt = self._add_holiday_nov_18(tr("Latvijas Republikas proklamēšanas diena"))
-        if year >= 2007:
+        if self._year >= 2007:
             self._add_observed(dt)
 
-        if year >= 2007:
+        if self._year >= 2007:
             # Christmas Eve.
             self._add_christmas_eve(tr("Ziemassvētku vakars"))
 

--- a/holidays/countries/lesotho.py
+++ b/holidays/countries/lesotho.py
@@ -30,11 +30,9 @@ class Lesotho(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolid
         StaticHolidays.__init__(self, LesothoStaticHolidays)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1995:
+    def _populate_public_holidays(self):
+        if self._year <= 1995:
             return None
-
-        super()._populate(year)
 
         # New Year's Day.
         self._add_new_years_day("New Year's Day")
@@ -42,11 +40,11 @@ class Lesotho(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolid
         # Moshoeshoe's Day.
         self._add_holiday_mar_11("Moshoeshoe's Day")
 
-        if year <= 2002:
+        if self._year <= 2002:
             # Heroes Day.
             self._add_holiday_apr_4("Heroes Day")
 
-        if year >= 2003:
+        if self._year >= 2003:
             # Africa/Heroes Day.
             self._add_africa_day("Africa/Heroes Day")
 
@@ -65,7 +63,7 @@ class Lesotho(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolid
         # https://en.wikipedia.org/wiki/Letsie_III
         # King's Birthday.
         name = "King's Birthday"
-        if year >= 1998:
+        if self._year >= 1998:
             self._add_holiday_jul_17(name)
         else:
             self._add_holiday_may_2(name)

--- a/holidays/countries/lithuania.py
+++ b/holidays/countries/lithuania.py
@@ -33,10 +33,9 @@ class Lithuania(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year) -> None:
-        if year <= 1989:
+    def _populate_public_holidays(self) -> None:
+        if self._year <= 1989:
             return None
-        super()._populate(year)
 
         # New Year's Day.
         self._add_new_years_day(tr("Naujųjų metų diena"))
@@ -62,11 +61,11 @@ class Lithuania(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Fathers's day. First Sunday in June.
         self._add_holiday_1st_sun_of_jun(tr("Tėvo diena"))
 
-        if year >= 2003:
+        if self._year >= 2003:
             # Day of Dew and Saint John.
             self._add_saint_johns_day(tr("Rasos ir Joninių diena"))
 
-        if year >= 1991:
+        if self._year >= 1991:
             self._add_holiday_jul_6(
                 # Statehood Day.
                 tr(
@@ -81,7 +80,7 @@ class Lithuania(HolidayBase, ChristianHolidays, InternationalHolidays):
         # All Saints' Day.
         self._add_all_saints_day(tr("Visų Šventųjų diena"))
 
-        if year >= 2020:
+        if self._year >= 2020:
             # All Souls' Day.
             self._add_all_souls_day(tr("Mirusiųjų atminimo (Vėlinių) diena"))
 

--- a/holidays/countries/luxembourg.py
+++ b/holidays/countries/luxembourg.py
@@ -29,9 +29,7 @@ class Luxembourg(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("Neijoerschdag"))
 
@@ -41,7 +39,7 @@ class Luxembourg(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Labor Day.
         self._add_labor_day(tr("Dag vun der Aarbecht"))
 
-        if year >= 2019:
+        if self._year >= 2019:
             # Europe Day.
             self._add_holiday_may_9(tr("Europadag"))
 

--- a/holidays/countries/madagascar.py
+++ b/holidays/countries/madagascar.py
@@ -33,12 +33,10 @@ class Madagascar(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # Observed since 1947
-        if year <= 1946:
+        if self._year <= 1946:
             return None
-
-        super()._populate(year)
 
         # New Year's Day.
         self._add_new_years_day(tr("Taom-baovao"))
@@ -77,7 +75,7 @@ class Madagascar(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Father's Day.
         self._add_holiday_3rd_sun_of_jun(tr("Fetin'ny ray"))
 
-        if year >= 1960:
+        if self._year >= 1960:
             # Independence Day.
             self._add_holiday_jun_26(tr("Fetin'ny fahaleovantena"))
 
@@ -87,7 +85,7 @@ class Madagascar(HolidayBase, ChristianHolidays, InternationalHolidays):
         # All Saints' Day.
         self._add_all_saints_day(tr("Fetin'ny olo-masina"))
 
-        if year >= 2011:
+        if self._year >= 2011:
             # Republic Day.
             self._add_holiday_dec_11(tr("Fetin'ny Repoblika"))
 

--- a/holidays/countries/malawi.py
+++ b/holidays/countries/malawi.py
@@ -32,12 +32,10 @@ class Malawi(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # Observed since 2000
-        if year <= 1999:
+        if self._year <= 1999:
             return None
-
-        super()._populate(year)
 
         self._add_observed(self._add_new_years_day("New Year's Day"))
 

--- a/holidays/countries/malaysia.py
+++ b/holidays/countries/malaysia.py
@@ -136,8 +136,7 @@ class Malaysia(
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_WORKDAY)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
+    def _populate_public_holidays(self):
         dts_observed = set()
 
         # Chinese New Year (one day in the States of Kelantan and Terengganu,
@@ -156,11 +155,11 @@ class Malaysia(
 
         # Birthday of [His Majesty] the Yang di-Pertuan Agong.
         name = "Birthday of SPB Yang di-Pertuan Agong"
-        if year <= 2017:
+        if self._year <= 2017:
             dts_observed.add(self._add_holiday_1st_sat_of_jun(name))
-        elif year == 2018:
+        elif self._year == 2018:
             dts_observed.add(self._add_holiday_sep_9(name))
-        elif year == 2020:
+        elif self._year == 2020:
             # https://www.nst.com.my/news/nation/2020/03/571660/agongs-birthday-moved-june-6-june-8
             dts_observed.add(self._add_holiday_jun_8(name))
         else:
@@ -170,7 +169,7 @@ class Malaysia(
         dts_observed.add(self._add_holiday_aug_31("National Day"))
 
         # Malaysia Day.
-        if year >= 2010:
+        if self._year >= 2010:
             dts_observed.add(self._add_holiday_sep_16("Malaysia Day"))
 
         # Deepavali (Diwali).
@@ -220,7 +219,7 @@ class Malaysia(
             dts_observed.add(self._add_new_years_day("New Year's Day"))
 
         # Isra and Mi'raj.
-        if self.subdiv in {"KDH", "NSN", "PLS"} or (self.subdiv == "TRG" and year >= 2020):
+        if self.subdiv in {"KDH", "NSN", "PLS"} or (self.subdiv == "TRG" and self._year >= 2020):
             dts_observed.update(self._add_isra_and_miraj_day("Isra and Mi'raj"))
 
         # Beginning of Ramadan.
@@ -236,13 +235,13 @@ class Malaysia(
             dts_observed.add(self._add_thaipusam("Thaipusam"))
 
         # Federal Territory Day.
-        if self.subdiv in {"KUL", "LBN", "PJY"} and year >= 1974:
+        if self.subdiv in {"KUL", "LBN", "PJY"} and self._year >= 1974:
             dts_observed.add(self._add_holiday_feb_1("Federal Territory Day"))
 
         # State holidays (single state)
 
         if self.subdiv == "MLK":
-            if year >= 1989:
+            if self._year >= 1989:
                 dts_observed.add(
                     self._add_holiday_apr_15("Declaration of Malacca as a Historical City")
                 )
@@ -250,36 +249,42 @@ class Malaysia(
             name = "Birthday of the Governor of Malacca"
             dts_observed.add(
                 self._add_holiday_aug_24(name)
-                if year >= 2020
+                if self._year >= 2020
                 else self._add_holiday_2nd_fri_of_oct(name)
             )
 
-        elif self.subdiv == "NSN" and year >= 2009:
+        elif self.subdiv == "NSN" and self._year >= 2009:
             dts_observed.add(self._add_holiday_jan_14("Birthday of the Sultan of Negeri Sembilan"))
 
-        elif self.subdiv == "PHG" and year >= 1975:
+        elif self.subdiv == "PHG" and self._year >= 1975:
             name = "Hari Hol of Pahang"
             dts_observed.add(
-                self._add_holiday_may_22(name) if year >= 2021 else self._add_holiday_may_7(name)
+                self._add_holiday_may_22(name)
+                if self._year >= 2021
+                else self._add_holiday_may_7(name)
             )
 
             name = "Birthday of the Sultan of Pahang"
             dts_observed.add(
-                self._add_holiday_jul_30(name) if year >= 2019 else self._add_holiday_oct_24(name)
+                self._add_holiday_jul_30(name)
+                if self._year >= 2019
+                else self._add_holiday_oct_24(name)
             )
 
         elif self.subdiv == "PNG":
-            if year >= 2009:
+            if self._year >= 2009:
                 dts_observed.add(self._add_holiday_jul_7("George Town Heritage Day"))
 
             dts_observed.add(
                 self._add_holiday_2nd_sat_of_jul("Birthday of the Governor of Penang")
             )
 
-        elif self.subdiv == "PLS" and year >= 2000:
+        elif self.subdiv == "PLS" and self._year >= 2000:
             name = "Birthday of The Raja of Perlis"
             dts_observed.add(
-                self._add_holiday_jul_17(name) if year >= 2018 else self._add_holiday_may_17(name)
+                self._add_holiday_jul_17(name)
+                if self._year >= 2018
+                else self._add_holiday_may_17(name)
             )
 
         elif self.subdiv == "SGR":
@@ -297,10 +302,10 @@ class Malaysia(
             )
 
             # Sarawak Independence Day
-            if year >= 2017:
+            if self._year >= 2017:
                 dts_observed.add(self._add_holiday_jul_22("Sarawak Day"))
 
-        elif self.subdiv == "TRG" and year >= 2000:
+        elif self.subdiv == "TRG" and self._year >= 2000:
             dts_observed.add(
                 self._add_holiday_mar_4(
                     "Anniversary of the Installation of the Sultan of Terengganu"
@@ -320,10 +325,10 @@ class Malaysia(
             self._populate_observed(dts_observed)
 
             # Special cases observed from previous year.
-            if year == 2007 and self.subdiv not in {"JHR", "KDH", "KTN", "TRG"}:
+            if self._year == 2007 and self.subdiv not in {"JHR", "KDH", "KTN", "TRG"}:
                 self._add_holiday_jan_2(self.observed_label % "Hari Raya Haji")
 
-            if year == 2007 and self.subdiv == "TRG":
+            if self._year == 2007 and self.subdiv == "TRG":
                 self._add_holiday_jan_2(self.observed_label % "Arafat Day")
 
         # The last two days in May (Pesta Kaamatan).
@@ -339,13 +344,13 @@ class Malaysia(
         self._add_islamic_new_year_day("Awal Muharram (Hijri New Year)")
 
         # Special holidays (states)
-        if year == 2021 and self.subdiv in {"KUL", "LBN", "PJY"}:
+        if self._year == 2021 and self.subdiv in {"KUL", "LBN", "PJY"}:
             self._add_holiday_dec_3("Malaysia Cup Holiday")
 
-        if year == 2022 and self.subdiv == "KDH":
+        if self._year == 2022 and self.subdiv == "KDH":
             self._add_holiday_jan_18("Thaipusam")
 
-        if year == 2022 and self.subdiv in {"JHR", "KDH", "KTN", "TRG"}:
+        if self._year == 2022 and self.subdiv in {"JHR", "KDH", "KTN", "TRG"}:
             self._add_holiday_may_4("Labour Day Holiday")
 
         # Multiple state holidays.
@@ -355,16 +360,16 @@ class Malaysia(
 
         # Single state holidays.
         if self.subdiv == "JHR":
-            if year >= 2015:
+            if self._year >= 2015:
                 self._add_holiday_mar_23("Birthday of the Sultan of Johor")
 
-            if year >= 2011:
+            if self._year >= 2011:
                 self._add_hari_hol_johor("Hari Hol of Sultan Iskandar of Johor")
 
-        elif self.subdiv == "KDH" and year >= 2020:
+        elif self.subdiv == "KDH" and self._year >= 2020:
             self._add_holiday_3rd_sun_of_jun("Birthday of The Sultan of Kedah")
 
-        elif self.subdiv == "KTN" and year >= 2010:
+        elif self.subdiv == "KTN" and self._year >= 2010:
             name = "Birthday of the Sultan of Kelantan"
             self._add_holiday_nov_11(name)
             self._add_holiday_nov_12(name)
@@ -373,7 +378,7 @@ class Malaysia(
             # This Holiday used to be on 27th until 2017
             # https://www.officeholidays.com/holidays/malaysia/birthday-of-the-sultan-of-perak
             name = "Birthday of the Sultan of Perak"
-            if year >= 2018:
+            if self._year >= 2018:
                 self._add_holiday_1st_fri_of_nov(name)
             else:
                 self._add_holiday_nov_27(name)
@@ -381,7 +386,7 @@ class Malaysia(
         elif self.subdiv == "SBH":
             self._add_holiday_1st_sat_of_oct("Birthday of the Governor of Sabah")
 
-            if year >= 2019:
+            if self._year >= 2019:
                 self._add_christmas_eve("Christmas Eve")
 
 

--- a/holidays/countries/maldives.py
+++ b/holidays/countries/maldives.py
@@ -30,9 +30,7 @@ class Maldives(HolidayBase, InternationalHolidays, IslamicHolidays):
         IslamicHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day("New Year's Day")
 

--- a/holidays/countries/malta.py
+++ b/holidays/countries/malta.py
@@ -45,11 +45,10 @@ class Malta(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # Earliest available source is 1980
-        if year <= 1979:
+        if self._year <= 1979:
             return None
-        super()._populate(year)
 
         # L-Ewwel tas-Sena
         # Status: In-Use.
@@ -61,7 +60,7 @@ class Malta(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Status: In-Use.
         # Started in 1987 via Act LX of 1987.
 
-        if year >= 1987:
+        if self._year >= 1987:
             # Feast of St. Paul's Shipwreck
             self._add_holiday_feb_10(tr("Il-Festa tan-Nawfraġju ta' San Pawl"))
 
@@ -69,7 +68,7 @@ class Malta(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Status: In-Use.
         # Started in 1987 via Act LX of 1987.
 
-        if year >= 1987:
+        if self._year >= 1987:
             # Feast of St. Joseph
             self._add_saint_josephs_day(tr("Il-Festa ta' San Ġużepp"))
 
@@ -78,7 +77,7 @@ class Malta(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Started in 1980 Act X of 1980.
         # Not presented in 1987-1988
 
-        if year <= 1986 or year >= 1989:
+        if self._year <= 1986 or self._year >= 1989:
             # Freedom Day
             self._add_holiday_mar_31(tr("Jum il-Ħelsien"))
 
@@ -98,7 +97,7 @@ class Malta(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Status: In-Use.
         # Start in 1989 via Act VIII of 1989.
 
-        if year >= 1989:
+        if self._year >= 1989:
             # Sette Giugno
             self._add_holiday_jun_7(tr("Sette Giugno"))
 
@@ -106,7 +105,7 @@ class Malta(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Status: In-Use.
         # Started in 1987 via Act LX of 1987.
 
-        if year >= 1987:
+        if self._year >= 1987:
             # Feast of St. Peter and St. Paul
             self._add_saints_peter_and_paul_day(tr("Il-Festa ta' San Pietru u San Pawl"))
 
@@ -121,7 +120,7 @@ class Malta(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Started in 1987 via Act LX of 1987.
         # While this concides with Nativity Of Mary Day, the two are considered separate.
 
-        if year >= 1987:
+        if self._year >= 1987:
             # Feast of Our Lady of Victories
             self._add_holiday_sep_8(tr("Jum il-Vitorja"))
 
@@ -129,7 +128,7 @@ class Malta(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Status: In-Use.
         # Started in 1987 via Act LX of 1987.
 
-        if year >= 1987:
+        if self._year >= 1987:
             # Independence Day
             self._add_holiday_sep_21(tr("Jum l-Indipendenza"))
 
@@ -137,7 +136,7 @@ class Malta(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Status: In-Use.
         # Started in 1987 via Act LX of 1987.
 
-        if year >= 1987:
+        if self._year >= 1987:
             # Feast of the Immaculate Conception
             self._add_immaculate_conception_day(tr("Il-Festa tal-Immakulata Kunċizzjoni"))
 

--- a/holidays/countries/marshall_islands.py
+++ b/holidays/countries/marshall_islands.py
@@ -32,10 +32,8 @@ class HolidaysMH(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, 
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
-        if year <= 2019:
+    def _populate_public_holidays(self):
+        if self._year <= 2019:
             warnings.warn(
                 "Years before 2020 are not available for the Marshall Islands (MH).", Warning
             )
@@ -69,7 +67,7 @@ class HolidaysMH(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, 
 
         # Christmas Day
         name = "Christmas Day"
-        if year == 2021:
+        if self._year == 2021:
             # special case
             self._add_holiday_dec_24(name)
         else:

--- a/holidays/countries/mexico.py
+++ b/holidays/countries/mexico.py
@@ -33,46 +33,44 @@ class Mexico(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("Año Nuevo"))
 
-        if year >= 1917:
+        if self._year >= 1917:
             # Constitution Day.
             name = tr("Día de la Constitución")
-            if year >= 2006:
+            if self._year >= 2006:
                 self._add_holiday_1st_mon_of_feb(name)
             else:
                 self._add_holiday_feb_5(name)
 
-        if year >= 1917:
+        if self._year >= 1917:
             # Benito Juárez's birthday.
             name = tr("Natalicio de Benito Juárez")
             # no 2006 due to celebration of the 200th anniversary
             # of Benito Juárez in 2006
-            if year >= 2007:
+            if self._year >= 2007:
                 self._add_holiday_3rd_mon_of_mar(name)
             else:
                 self._add_holiday_mar_21(name)
 
-        if year >= 1923:
+        if self._year >= 1923:
             # Labor Day.
             self._add_labor_day(tr("Día del Trabajo"))
 
         # Independence Day.
         self._add_holiday_sep_16(tr("Día de la Independencia"))
 
-        if year >= 1917:
+        if self._year >= 1917:
             # Revolution Day.
             name = tr("Día de la Revolución")
-            if year >= 2006:
+            if self._year >= 2006:
                 self._add_holiday_3rd_mon_of_nov(name)
             else:
                 self._add_holiday_nov_20(name)
 
-        if year >= 1970 and (year - 1970) % 6 == 0:
+        if self._year >= 1970 and (self._year - 1970) % 6 == 0:
             # Change of Federal Government.
             self._add_holiday_dec_1(tr("Transmisión del Poder Ejecutivo Federal"))
 

--- a/holidays/countries/moldova.py
+++ b/holidays/countries/moldova.py
@@ -33,10 +33,9 @@ class Moldova(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1990:
+    def _populate_public_holidays(self):
+        if self._year <= 1990:
             return None
-        super()._populate(year)
 
         # New Year's Day.
         self._add_new_years_day(tr("Anul Nou"))
@@ -44,7 +43,7 @@ class Moldova(HolidayBase, ChristianHolidays, InternationalHolidays):
         name = (
             # Christmas (by old style).
             tr("Naşterea lui Iisus Hristos (Crăciunul pe stil vechi)")
-            if year >= 2014
+            if self._year >= 2014
             # Christmas.
             else tr("Naşterea lui Iisus Hristos (Crăciunul)")
         )
@@ -71,11 +70,11 @@ class Moldova(HolidayBase, ChristianHolidays, InternationalHolidays):
             tr("Ziua Victoriei şi a comemorării eroilor căzuţi pentru Independenţa Patriei")
         )
 
-        if year >= 2017:
+        if self._year >= 2017:
             # Europe Day.
             self._add_holiday(tr("Ziua Europei"), may_9)
 
-        if year >= 2016:
+        if self._year >= 2016:
             # International Children's Day
             self._add_childrens_day(tr("Ziua Ocrotirii Copilului"))
 
@@ -85,7 +84,7 @@ class Moldova(HolidayBase, ChristianHolidays, InternationalHolidays):
         # National Language Day.
         self._add_holiday_aug_31(tr("Limba noastră"))
 
-        if year >= 2013:
+        if self._year >= 2013:
             self._add_christmas_day(
                 # Christmas (by new style).
                 tr("Naşterea lui Iisus Hristos (Crăciunul pe stil nou)"),

--- a/holidays/countries/monaco.py
+++ b/holidays/countries/monaco.py
@@ -35,9 +35,7 @@ class Monaco(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_observed(self._add_new_years_day(tr("Le jour de l'An")))
 
@@ -70,7 +68,7 @@ class Monaco(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
 
         # Immaculate Conception Day.
         name = tr("L'Immaculée Conception")
-        if year >= 2019 and self._is_sunday(DEC, 8):
+        if self._year >= 2019 and self._is_sunday(DEC, 8):
             self._add_holiday_dec_9(name)
         else:
             self._add_holiday_dec_8(name)

--- a/holidays/countries/montenegro.py
+++ b/holidays/countries/montenegro.py
@@ -32,9 +32,7 @@ class Montenegro(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         name = "New Year's Day"
         self._add_observed(self._add_new_years_day(name), rule=SUN_TO_NEXT_TUE)

--- a/holidays/countries/morocco.py
+++ b/holidays/countries/morocco.py
@@ -35,19 +35,17 @@ class Morocco(HolidayBase, InternationalHolidays, IslamicHolidays):
         IslamicHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("رأس السنة الميلادية"))
 
-        if year >= 1945:
+        if self._year >= 1945:
             # Proclamation of Independence Day.
             self._add_holiday_jan_11(tr("ذكرى تقديم وثيقة الاستقلال"))
 
         # In May 2023, Morocco recognized Berber New Year as official holiday.
         # http://www.diplomatie.ma/en/statement-royal-office-12
-        if year >= 2024:
+        if self._year >= 2024:
             # Amazigh New Year.
             self._add_holiday_jan_13(tr("رأس السنة الأمازيغية"))
 
@@ -56,9 +54,9 @@ class Morocco(HolidayBase, InternationalHolidays, IslamicHolidays):
 
         # Throne day.
         name = tr("عيد العرش")
-        if year >= 2001:
+        if self._year >= 2001:
             self._add_holiday_jul_30(name)
-        elif year >= 1963:
+        elif self._year >= 1963:
             self._add_holiday_mar_3(name)
         else:
             self._add_holiday_nov_18(name)
@@ -71,16 +69,16 @@ class Morocco(HolidayBase, InternationalHolidays, IslamicHolidays):
 
         # Youth Day.
         name = tr("عيد الشباب")
-        if year >= 2001:
+        if self._year >= 2001:
             self._add_holiday_aug_21(name)
         else:
             self._add_holiday_jul_9(name)
 
-        if year >= 1976:
+        if self._year >= 1976:
             # Green March.
             self._add_holiday_nov_6(tr("ذكرى المسيرة الخضراء"))
 
-        if year >= 1957:
+        if self._year >= 1957:
             # Independence Day.
             self._add_holiday_nov_18(tr("عيد الإستقلال"))
 

--- a/holidays/countries/mozambique.py
+++ b/holidays/countries/mozambique.py
@@ -28,11 +28,9 @@ class Mozambique(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1974:
+    def _populate_public_holidays(self):
+        if self._year <= 1974:
             return None
-
-        super()._populate(year)
 
         # International Fraternalism Day.
         self._add_observed(self._add_new_years_day(tr("Dia da Fraternidade universal")))
@@ -57,7 +55,7 @@ class Mozambique(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
             self._add_holiday_sep_25(tr("Dia das Forças Armadas de Libertação Nacional"))
         )
 
-        if year >= 1993:
+        if self._year >= 1993:
             # Peace and Reconciliation Day.
             self._add_observed(self._add_holiday_oct_4(tr("Dia da Paz e Reconciliação")))
 

--- a/holidays/countries/namibia.py
+++ b/holidays/countries/namibia.py
@@ -38,11 +38,9 @@ class Namibia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Sta
         kwargs.setdefault("observed_since", 1991)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1989:
+    def _populate_public_holidays(self):
+        if self._year <= 1989:
             return None
-
-        super()._populate(year)
 
         # New Year's Day.
         self._add_observed(self._add_new_years_day("New Year's Day"))
@@ -75,7 +73,7 @@ class Namibia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Sta
         self._add_observed(
             self._add_holiday_sep_10(
                 "Day of the Namibian Women and International Human Rights Day"
-                if year >= 2005
+                if self._year >= 2005
                 else "International Human Rights Day",
             )
         )

--- a/holidays/countries/new_zealand.py
+++ b/holidays/countries/new_zealand.py
@@ -79,7 +79,7 @@ class NewZealand(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, 
         dt = dt if isinstance(dt, date) else date(self._year, *dt)
         return self._get_observed_date(dt, rule=ALL_TO_NEAREST_MON)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # Bank Holidays Act 1873
         # The Employment of Females Act 1873
         # Factories Act 1894
@@ -91,10 +91,8 @@ class NewZealand(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, 
         # Sovereign's Birthday Observance Act 1937, 1952
         # Holidays Act 1981, 2003
 
-        if year <= 1893:
+        if self._year <= 1893:
             return None
-
-        super()._populate(year)
 
         # New Year's Day
         self._add_observed(self._add_new_years_day("New Year's Day"), rule=SAT_SUN_TO_NEXT_MON_TUE)
@@ -103,16 +101,16 @@ class NewZealand(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, 
         )
 
         # Waitangi Day
-        if year >= 1974:
-            name = "Waitangi Day" if year >= 1977 else "New Zealand Day"
+        if self._year >= 1974:
+            name = "Waitangi Day" if self._year >= 1977 else "New Zealand Day"
             feb_6 = self._add_holiday_feb_6(name)
-            if year >= 2014:
+            if self._year >= 2014:
                 self._add_observed(feb_6)
 
         # Anzac Day
-        if year >= 1921:
+        if self._year >= 1921:
             apr_25 = self._add_anzac_day("Anzac Day")
-            if year >= 2014:
+            if self._year >= 2014:
                 self._add_observed(apr_25)
 
         # Easter
@@ -120,17 +118,17 @@ class NewZealand(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, 
         self._add_easter_monday("Easter Monday")
 
         # Sovereign's Birthday
-        if year >= 1902:
-            name = "Queen's Birthday" if 1952 <= year <= 2022 else "King's Birthday"
-            if year == 1952:
+        if self._year >= 1902:
+            name = "Queen's Birthday" if 1952 <= self._year <= 2022 else "King's Birthday"
+            if self._year == 1952:
                 self._add_holiday_jun_2(name)  # Elizabeth II
-            elif year >= 1938:
+            elif self._year >= 1938:
                 self._add_holiday_1st_mon_of_jun(name)  # EII & GVI
-            elif year == 1937:
+            elif self._year == 1937:
                 self._add_holiday_jun_9(name)  # George VI
-            elif year == 1936:
+            elif self._year == 1936:
                 self._add_holiday_jun_23(name)  # Edward VIII
-            elif year >= 1912:
+            elif self._year >= 1912:
                 self._add_holiday_jun_3(name)  # George V
             else:
                 # http://paperspast.natlib.govt.nz/cgi-bin/paperspast?a=d&d=NZH19091110.2.67
@@ -170,13 +168,13 @@ class NewZealand(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, 
             2051: (JUN, 30),
             2052: (JUN, 21),
         }
-        if year in dates_obs:
-            self._add_holiday("Matariki", dates_obs[year])
+        if self._year in dates_obs:
+            self._add_holiday("Matariki", dates_obs[self._year])
 
         # Labour Day
-        if year >= 1900:
+        if self._year >= 1900:
             name = "Labour Day"
-            if year >= 1910:
+            if self._year >= 1910:
                 self._add_holiday_4th_mon_of_oct(name)
             else:
                 self._add_holiday_2nd_wed_of_oct(name)

--- a/holidays/countries/nicaragua.py
+++ b/holidays/countries/nicaragua.py
@@ -47,9 +47,7 @@ class Nicaragua(HolidayBase, ChristianHolidays, InternationalHolidays):
             kwargs["subdiv"] = "MN"
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("Año Nuevo"))
 
@@ -62,7 +60,7 @@ class Nicaragua(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Labor Day.
         self._add_labor_day(tr("Día del Trabajo"))
 
-        if year >= 1979:
+        if self._year >= 1979:
             # Revolution Day.
             self._add_holiday_jul_19(tr("Día de la Revolución"))
 

--- a/holidays/countries/nigeria.py
+++ b/holidays/countries/nigeria.py
@@ -38,11 +38,10 @@ class Nigeria(
         kwargs.setdefault("observed_since", 2016)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1978:
+    def _populate_public_holidays(self):
+        if self._year <= 1978:
             return None
 
-        super()._populate(year)
         dts_observed = set()
 
         # New Year's Day.
@@ -52,14 +51,16 @@ class Nigeria(
         self._add_easter_monday("Easter Monday")
 
         # Worker's day.
-        if year >= 1981:
+        if self._year >= 1981:
             dts_observed.add(self._add_labor_day("Workers' Day"))
 
         # Democracy Day.
-        if year >= 2000:
+        if self._year >= 2000:
             name = "Democracy Day"
             dts_observed.add(
-                self._add_holiday_jun_12(name) if year >= 2019 else self._add_holiday_may_29(name)
+                self._add_holiday_jun_12(name)
+                if self._year >= 2019
+                else self._add_holiday_may_29(name)
             )
 
         # Independence Day.

--- a/holidays/countries/north_macedonia.py
+++ b/holidays/countries/north_macedonia.py
@@ -27,9 +27,7 @@ class NorthMacedonia(HolidayBase, ChristianHolidays, InternationalHolidays, Isla
         IslamicHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         self._add_new_years_day("New Year's Day")
 
         self._add_christmas_day("Christmas Day (Orthodox)")

--- a/holidays/countries/northern_mariana_islands.py
+++ b/holidays/countries/northern_mariana_islands.py
@@ -20,9 +20,9 @@ class HolidaysMP(US):
     country = "MP"
     subdivisions = ()  # Override US subdivisions.
 
-    def _populate(self, year: int) -> None:
+    def _populate_public_holidays(self) -> None:
         self.subdiv = "MP"
-        super()._populate(year)
+        super()._populate_public_holidays()
 
 
 class MP(HolidaysMP):

--- a/holidays/countries/norway.py
+++ b/holidays/countries/norway.py
@@ -46,9 +46,7 @@ class Norway(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("Første nyttårsdag"))
 
@@ -65,7 +63,7 @@ class Norway(HolidayBase, ChristianHolidays, InternationalHolidays):
         self._add_easter_monday(tr("Andre påskedag"))
 
         # Source: https://lovdata.no/dokument/NL/lov/1947-04-26-1
-        if year >= 1947:
+        if self._year >= 1947:
             # Labour Day.
             self._add_labor_day(tr("Arbeidernes dag"))
 
@@ -93,7 +91,7 @@ class Norway(HolidayBase, ChristianHolidays, InternationalHolidays):
 
         if self.include_sundays:
             # Optionally add all Sundays of the year.
-            for dt in _get_all_sundays(year):
+            for dt in _get_all_sundays(self._year):
                 # Sunday.
                 self._add_holiday(tr("Søndag"), dt)
 

--- a/holidays/countries/pakistan.py
+++ b/holidays/countries/pakistan.py
@@ -23,29 +23,27 @@ class Pakistan(HolidayBase, InternationalHolidays, IslamicHolidays):
         IslamicHolidays.__init__(self, cls=PakistanIslamicHolidays)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1947:
+    def _populate_public_holidays(self):
+        if self._year <= 1947:
             return None
 
-        super()._populate(year)
-
         # Kashmir Solidarity Day.
-        if year >= 1990:
+        if self._year >= 1990:
             self._add_holiday_feb_5("Kashmir Solidarity Day")
 
         # Pakistan Day.
-        if year >= 1956:
+        if self._year >= 1956:
             self._add_holiday_mar_23("Pakistan Day")
 
         # Labour Day.
-        if year >= 1972:
+        if self._year >= 1972:
             self._add_labor_day("Labour Day")
 
         # Independence Day.
         self._add_holiday_aug_14("Independence Day")
 
         # Iqbal Day.
-        if year <= 2014 or year >= 2022:
+        if self._year <= 2014 or self._year >= 2022:
             self._add_holiday_nov_9("Iqbal Day")
 
         # Quaid-e-Azam Day.

--- a/holidays/countries/panama.py
+++ b/holidays/countries/panama.py
@@ -29,9 +29,7 @@ class Panama(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day
         self._add_observed(self._add_new_years_day("New Year's Day"))
 
@@ -66,7 +64,7 @@ class Panama(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         self._add_observed(self._add_holiday_dec_8("Mother's Day"))
 
         # National Mourning Day
-        if year >= 2022:
+        if self._year >= 2022:
             self._add_observed(self._add_holiday_dec_20("National Mourning Day"))
 
         # Christmas Day

--- a/holidays/countries/paraguay.py
+++ b/holidays/countries/paraguay.py
@@ -38,9 +38,7 @@ class Paraguay(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHoli
         if not self.observed and self._is_weekend(dt):
             self.pop(dt)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._move_holiday(self._add_new_years_day(tr("Año Nuevo")))
 
@@ -50,8 +48,12 @@ class Paraguay(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHoli
             2018: (FEB, 26),
             2022: (FEB, 28),
         }
-        # Patriots Day.
-        self._add_holiday(tr("Día de los Héroes de la Patria"), dates_obs.get(year, (MAR, 1)))
+
+        self._add_holiday(
+            # Patriots Day.
+            tr("Día de los Héroes de la Patria"),
+            dates_obs.get(self._year, (MAR, 1)),
+        )
 
         # Maundy Thursday.
         self._add_holy_thursday(tr("Jueves Santo"))
@@ -67,10 +69,10 @@ class Paraguay(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHoli
 
         # Independence Day.
         name = tr("Día de la Independencia Nacional")
-        if year >= 2012:
+        if self._year >= 2012:
             self._move_holiday(self._add_holiday_may_14(name))
         may_15 = self._add_holiday_may_15(name)
-        if year != 2021:
+        if self._year != 2021:
             self._move_holiday(may_15)
 
         dates_obs = {
@@ -79,13 +81,13 @@ class Paraguay(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHoli
         }
         self._move_holiday(
             # Chaco Armistice Day.
-            self._add_holiday(tr("Día de la Paz del Chaco"), dates_obs.get(year, (JUN, 12)))
+            self._add_holiday(tr("Día de la Paz del Chaco"), dates_obs.get(self._year, (JUN, 12)))
         )
 
         # Asuncion Foundation's Day.
         self._move_holiday(self._add_holiday_aug_15(tr("Día de la Fundación de Asunción")))
 
-        if year >= 2000:
+        if self._year >= 2000:
             dates_obs = {
                 2015: (SEP, 28),
                 2016: (OCT, 3),
@@ -97,7 +99,7 @@ class Paraguay(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHoli
                 self._add_holiday(
                     # Boqueron Battle Day.
                     tr("Día de la Batalla de Boquerón"),
-                    dates_obs.get(year, (SEP, 29)),
+                    dates_obs.get(self._year, (SEP, 29)),
                 )
             )
 

--- a/holidays/countries/peru.py
+++ b/holidays/countries/peru.py
@@ -34,9 +34,7 @@ class Peru(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("Año Nuevo"))
 
@@ -61,7 +59,7 @@ class Peru(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Great Military Parade Day.
         self._add_holiday_jul_29(tr("Día de la Gran Parada Militar"))
 
-        if year >= 2022:
+        if self._year >= 2022:
             # Battle of Junín.
             self._add_holiday_aug_6(tr("Batalla de Junín"))
 
@@ -77,7 +75,7 @@ class Peru(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Immaculate Conception.
         self._add_immaculate_conception_day(tr("Inmaculada Concepción"))
 
-        if year >= 2022:
+        if self._year >= 2022:
             # Battle of Ayacucho.
             self._add_holiday_dec_9(tr("Batalla de Ayacucho"))
 

--- a/holidays/countries/philippines.py
+++ b/holidays/countries/philippines.py
@@ -38,9 +38,7 @@ class Philippines(
         IslamicHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day("New Year's Day")
 

--- a/holidays/countries/poland.py
+++ b/holidays/countries/poland.py
@@ -32,20 +32,18 @@ class Poland(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolida
         StaticHolidays.__init__(self, PolandStaticHolidays)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1924:
+    def _populate_public_holidays(self):
+        if self._year <= 1924:
             return None
-
-        super()._populate(year)
 
         # New Year's Day.
         self._add_new_years_day(tr("Nowy Rok"))
 
-        if year <= 1960 or year >= 2011:
+        if self._year <= 1960 or self._year >= 2011:
             # Epiphany.
             self._add_epiphany_day(tr("Święto Trzech Króli"))
 
-        if year <= 1950:
+        if self._year <= 1950:
             # Candlemas.
             self._add_candlemas(tr("Oczyszczenie Najświętszej Marii Panny"))
 
@@ -55,54 +53,54 @@ class Poland(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolida
         # Easter Monday.
         self._add_easter_monday(tr("Poniedziałek Wielkanocny"))
 
-        if year >= 1950:
+        if self._year >= 1950:
             # National Day.
             self._add_holiday_may_1(tr("Święto Państwowe"))
 
-        if year <= 1950 or year >= 1990:
+        if self._year <= 1950 or self._year >= 1990:
             # National Day of the Third of May.
             self._add_holiday_may_3(tr("Święto Narodowe Trzeciego Maja"))
 
-        if 1946 <= year <= 1950:
+        if 1946 <= self._year <= 1950:
             # National Victory and Freedom Day.
             self._add_holiday_may_9(tr("Narodowe Święto Zwycięstwa i Wolności"))
 
-        if year <= 1950:
+        if self._year <= 1950:
             # Ascension Day.
             self._add_holiday(tr("Wniebowstąpienie Pańskie"), self._easter_sunday + td(days=+40))
 
         # Pentecost.
         self._add_whit_sunday(tr("Zielone Świątki"))
 
-        if year <= 1950:
+        if self._year <= 1950:
             # Pentecost (Day 2).
             self._add_whit_monday(tr("Drugi dzień Zielonych Świątek"))
 
         # Corpus Christi.
         self._add_corpus_christi_day(tr("Dzień Bożego Ciała"))
 
-        if year <= 1950:
+        if self._year <= 1950:
             self._add_saints_peter_and_paul_day(
                 # Saints Peter and Paul Day.
                 tr("Uroczystość Świętych Apostołów Piotra i Pawła")
             )
 
-        if 1945 <= year <= 1989:
+        if 1945 <= self._year <= 1989:
             # National Day of Rebirth of Poland.
             self._add_holiday_jul_22(tr("Narodowe Święto Odrodzenia Polski"))
 
-        if year <= 1960 or year >= 1989:
+        if self._year <= 1960 or self._year >= 1989:
             # Assumption of the Virgin Mary.
             self._add_assumption_of_mary_day(tr("Wniebowzięcie Najświętszej Marii Panny"))
 
         # All Saints' Day.
         self._add_all_saints_day(tr("Uroczystość Wszystkich Świętych"))
 
-        if 1937 <= year <= 1944 or year >= 1989:
+        if 1937 <= self._year <= 1944 or self._year >= 1989:
             # National Independence Day.
             self._add_holiday_nov_11(tr("Narodowe Święto Niepodległości"))
 
-        if year <= 1950:
+        if self._year <= 1950:
             self._add_immaculate_conception_day(
                 # Immaculate Conception of the Blessed Virgin Mary.
                 tr("Niepokalane Poczęcie Najświętszej Marii Panny")

--- a/holidays/countries/puerto_rico.py
+++ b/holidays/countries/puerto_rico.py
@@ -20,9 +20,9 @@ class HolidaysPR(US):
     country = "PR"
     subdivisions = ()  # Override US subdivisions.
 
-    def _populate(self, year: int) -> None:
+    def _populate_public_holidays(self) -> None:
         self.subdiv = "PR"
-        super()._populate(year)
+        super()._populate_public_holidays()
 
 
 class PR(HolidaysPR):

--- a/holidays/countries/romania.py
+++ b/holidays/countries/romania.py
@@ -31,28 +31,26 @@ class Romania(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         name = tr("Anul Nou")
         self._add_new_years_day(name)
         self._add_new_years_day_two(name)
 
-        if year >= 2024:
+        if self._year >= 2024:
             # Epiphany.
             self._add_epiphany_day(tr("Bobotează"))
 
             # Saint John the Baptist.
             self._add_holiday_jan_7(tr("Sfântul Ion"))
 
-        if year >= 2016:
+        if self._year >= 2016:
             # Unification of the Romanian Principalities Day.
             self._add_holiday_jan_24(tr("Ziua Unirii Principatelor Române"))
 
         # Easter.
         name = tr("Paștele")
-        if year >= 2018:
+        if self._year >= 2018:
             self._add_good_friday(name)
 
         self._add_easter_sunday(name)
@@ -61,7 +59,7 @@ class Romania(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Labour Day.
         self._add_labor_day(tr("Ziua Muncii"))
 
-        if year >= 2017:
+        if self._year >= 2017:
             # Children's Day.
             self._add_childrens_day(tr("Ziua Copilului"))
 
@@ -71,12 +69,12 @@ class Romania(HolidayBase, ChristianHolidays, InternationalHolidays):
         self._add_whit_monday(name)
 
         # Law #202/2008
-        if year >= 2009:
+        if self._year >= 2009:
             # Dormition of the Mother of God.
             self._add_assumption_of_mary_day(tr("Adormirea Maicii Domnului"))
 
         # Law #147/2012
-        if year >= 2012:
+        if self._year >= 2012:
             # Saint Andrew's Day.
             self._add_holiday_nov_30(tr("Sfantul Apostol Andrei cel Intai chemat"))
 

--- a/holidays/countries/russia.py
+++ b/holidays/countries/russia.py
@@ -32,30 +32,29 @@ class Russia(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolida
         StaticHolidays.__init__(self, RussiaStaticHolidays)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1990:
+    def _populate_public_holidays(self):
+        if self._year <= 1990:
             return None
-        super()._populate(year)
 
-        if year <= 2004:
+        if self._year <= 2004:
             # New Year's Day.
             name = tr("Новый год")
             self._add_new_years_day(name)
-            if year >= 1993:
+            if self._year >= 1993:
                 self._add_new_years_day_two(name)
         else:
             # New Year Holidays.
             name = tr("Новогодние каникулы")
             for day in range(1, 6):
                 self._add_holiday(name, JAN, day)
-            if year >= 2013:
+            if self._year >= 2013:
                 self._add_holiday_jan_6(name)
                 self._add_holiday_jan_8(name)
 
         # Christmas Day.
         self._add_christmas_day(tr("Рождество Христово"))
 
-        if year >= 2002:
+        if self._year >= 2002:
             # Defender of the Fatherland Day.
             self._add_holiday_feb_23(tr("День защитника Отечества"))
 
@@ -65,42 +64,42 @@ class Russia(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolida
         name = (
             # Holiday of Spring and Labor.
             tr("Праздник Весны и Труда")
-            if year >= 1992
+            if self._year >= 1992
             # International Workers' Solidarity Day.
             else tr("День международной солидарности трудящихся")
         )
         self._add_labor_day(name)
-        if year <= 2004:
+        if self._year <= 2004:
             self._add_labor_day_two(name)
 
         # Victory Day.
         self._add_world_war_two_victory_day(tr("День Победы"))
 
-        if year >= 1992:
+        if self._year >= 1992:
             self._add_holiday_jun_12(
                 # Russia Day.
                 tr("День России")
-                if year >= 2002
+                if self._year >= 2002
                 # Day of the Adoption of the Declaration of Sovereignty of the Russian Federation.
                 else tr(
                     "День принятия Декларации о государственном суверенитете Российской Федерации"
                 )
             )
 
-        if year >= 2005:
+        if self._year >= 2005:
             # Unity Day.
             self._add_holiday_nov_4(tr("День народного единства"))
 
-        if year <= 2004:
+        if self._year <= 2004:
             name = (
                 # Day of consent and reconciliation.
                 tr("День согласия и примирения")
-                if year >= 1996
+                if self._year >= 1996
                 # Anniversary of the Great October Socialist Revolution.
                 else tr("Годовщина Великой Октябрьской социалистической революции")
             )
             self._add_holiday_nov_7(name)
-            if year <= 1991:
+            if self._year <= 1991:
                 self._add_holiday_nov_8(name)
 
 

--- a/holidays/countries/san_marino.py
+++ b/holidays/countries/san_marino.py
@@ -26,9 +26,7 @@ class SanMarino(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year: int) -> None:
-        super()._populate(year)
-
+    def _populate_public_holidays(self) -> None:
         # New Year's Day.
         self._add_new_years_day("New Year's Day")
 

--- a/holidays/countries/saudi_arabia.py
+++ b/holidays/countries/saudi_arabia.py
@@ -66,18 +66,16 @@ class SaudiArabia(ObservedHolidayBase, IslamicHolidays, StaticHolidays):
             for i in range(4):
                 self._add_observed(dt + td(days=-i), name=self[dt], rule=observed_rule)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # Weekend used to be THU, FRI before June 28th, 2013.
         # On that year both Eids were after that date, and Founding day
         # holiday started at 2022; so what below works.
         self._observed_rule = (
             THU_TO_PREV_WED + FRI_TO_NEXT_SAT
-            if year <= 2012
+            if self._year <= 2012
             else FRI_TO_PREV_THU + SAT_TO_NEXT_SUN
         )
-        self.weekend = {THU, FRI} if year <= 2012 else {FRI, SAT}
+        self.weekend = {THU, FRI} if self._year <= 2012 else {FRI, SAT}
 
         # Eid al-Fitr Holiday
         eid_al_fitr_name = tr("عطلة عيد الفطر")
@@ -96,16 +94,16 @@ class SaudiArabia(ObservedHolidayBase, IslamicHolidays, StaticHolidays):
 
         # If National Day happens within the Eid al-Fitr Holiday or
         # Eid al-Adha Holiday, there is no extra holidays given for it.
-        if year >= 2005:
-            dt = date(year, SEP, 23)
+        if self._year >= 2005:
+            dt = date(self._year, SEP, 23)
             if dt not in self:
                 # National Day Holiday
                 self._add_observed(self._add_holiday(tr("اليوم الوطني"), dt))
 
         # If Founding Day happens within the Eid al-Fitr Holiday or
         # Eid al-Adha Holiday, there is no extra holidays given for it.
-        if year >= 2022:
-            dt = date(year, FEB, 22)
+        if self._year >= 2022:
+            dt = date(self._year, FEB, 22)
             if dt not in self:
                 # Founding Day
                 self._add_observed(self._add_holiday(tr("يوم التأسيسي"), dt))

--- a/holidays/countries/serbia.py
+++ b/holidays/countries/serbia.py
@@ -36,9 +36,7 @@ class Serbia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         name = tr("Нова година")
         self._add_observed(self._add_new_years_day(name), rule=SUN_TO_NEXT_TUE)

--- a/holidays/countries/singapore.py
+++ b/holidays/countries/singapore.py
@@ -90,8 +90,7 @@ class Singapore(
         kwargs.setdefault("observed_since", 1998)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year) -> None:
-        super()._populate(year)
+    def _populate_public_holidays(self) -> None:
         dts_observed = set()
 
         # New Year's Day
@@ -104,7 +103,7 @@ class Singapore(
 
         # Hari Raya Puasa (Eid al-Fitr)
         dts_observed.update(self._add_eid_al_fitr_day("Hari Raya Puasa"))
-        if year <= 1968:
+        if self._year <= 1968:
             self._add_eid_al_fitr_day_two("Second day of Hari Raya Puasa")
 
         # Hari Raya Haji (Eid al-Adha)
@@ -113,7 +112,7 @@ class Singapore(
         # Good Friday
         self._add_good_friday("Good Friday")
 
-        if year <= 1968:
+        if self._year <= 1968:
             # Holy Saturday
             self._add_holy_saturday("Holy Saturday")
 
@@ -136,7 +135,7 @@ class Singapore(
         dts_observed.add(self._add_christmas_day("Christmas Day"))
 
         # Boxing day (up to and including 1968)
-        if year <= 1968:
+        if self._year <= 1968:
             self._add_christmas_day_two("Boxing Day")
 
         if self.observed:

--- a/holidays/countries/slovenia.py
+++ b/holidays/countries/slovenia.py
@@ -37,16 +37,14 @@ class Slovenia(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHoli
         StaticHolidays.__init__(self, SloveniaStaticHolidays)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1990:
+    def _populate_public_holidays(self):
+        if self._year <= 1990:
             return None
-
-        super()._populate(year)
 
         # New Year's Day.
         name = tr("novo leto")
         self._add_new_years_day(name)
-        if year <= 2012 or year >= 2017:
+        if self._year <= 2012 or self._year >= 2017:
             self._add_new_years_day_two(name)
 
         # Preseren's Day.
@@ -69,7 +67,7 @@ class Slovenia(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHoli
         # Assumption Day.
         self._add_assumption_of_mary_day(tr("Marijino vnebovzetje"))
 
-        if year >= 1992:
+        if self._year >= 1992:
             # Reformation Day.
             self._add_holiday_oct_31(tr("dan reformacije"))
 

--- a/holidays/countries/south_africa.py
+++ b/holidays/countries/south_africa.py
@@ -32,24 +32,22 @@ class SouthAfrica(ObservedHolidayBase, ChristianHolidays, InternationalHolidays,
         kwargs.setdefault("observed_since", 1995)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # Observed since 1910, with a few name changes
-        if year <= 1909:
+        if self._year <= 1909:
             return None
-
-        super()._populate(year)
 
         self._add_observed(self._add_new_years_day("New Year's Day"))
 
         self._add_good_friday("Good Friday")
 
-        self._add_easter_monday("Family Day" if year >= 1980 else "Easter Monday")
+        self._add_easter_monday("Family Day" if self._year >= 1980 else "Easter Monday")
 
-        if year <= 1951:
+        if self._year <= 1951:
             name = "Dingaan's Day"
-        elif year <= 1979:
+        elif self._year <= 1979:
             name = "Day of the Covenant"
-        elif year <= 1994:
+        elif self._year <= 1994:
             name = "Day of the Vow"
         else:
             name = "Day of Reconciliation"
@@ -58,10 +56,10 @@ class SouthAfrica(ObservedHolidayBase, ChristianHolidays, InternationalHolidays,
         self._add_christmas_day("Christmas Day")
 
         self._add_observed(
-            self._add_christmas_day_two("Day of Goodwill" if year >= 1980 else "Boxing Day")
+            self._add_christmas_day_two("Day of Goodwill" if self._year >= 1980 else "Boxing Day")
         )
 
-        if year >= 1995:
+        if self._year >= 1995:
             self._add_observed(self._add_holiday_mar_21("Human Rights Day"))
 
             self._add_observed(self._add_holiday_apr_27("Freedom Day"))
@@ -75,38 +73,38 @@ class SouthAfrica(ObservedHolidayBase, ChristianHolidays, InternationalHolidays,
             self._add_observed(self._add_holiday_sep_24("Heritage Day"))
 
         # Historic public holidays no longer observed
-        if 1952 <= year <= 1973:
+        if 1952 <= self._year <= 1973:
             self._add_holiday_apr_6("Van Riebeeck's Day")
-        elif 1980 <= year <= 1994:
+        elif 1980 <= self._year <= 1994:
             self._add_holiday_apr_6("Founder's Day")
 
-        if 1987 <= year <= 1989:
+        if 1987 <= self._year <= 1989:
             self._add_holiday_1st_fri_of_may("Workers' Day")
 
-        if year <= 1993:
+        if self._year <= 1993:
             self._add_ascension_thursday("Ascension Day")
 
-        if year <= 1951:
+        if self._year <= 1951:
             self._add_holiday_may_24("Empire Day")
 
-        if year <= 1960:
+        if self._year <= 1960:
             self._add_holiday_may_31("Union Day")
-        elif year <= 1993:
+        elif self._year <= 1993:
             self._add_holiday_may_31("Republic Day")
 
-        if 1952 <= year <= 1960:
+        if 1952 <= self._year <= 1960:
             self._add_holiday_2nd_mon_of_jul("Queen's Birthday")
 
-        if 1961 <= year <= 1973:
+        if 1961 <= self._year <= 1973:
             self._add_holiday_jul_10("Family Day")
 
-        if year <= 1951:
+        if self._year <= 1951:
             self._add_holiday_1st_mon_of_aug("King's Birthday")
 
-        if 1952 <= year <= 1979:
+        if 1952 <= self._year <= 1979:
             self._add_holiday_1st_mon_of_sep("Settlers' Day")
 
-        if 1952 <= year <= 1993:
+        if 1952 <= self._year <= 1993:
             self._add_holiday_oct_10("Kruger Day")
 
 

--- a/holidays/countries/spain.py
+++ b/holidays/countries/spain.py
@@ -72,35 +72,33 @@ class Spain(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Islam
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
-        if year not in {2012, 2017, 2023}:
+    def _populate_public_holidays(self):
+        if self._year not in {2012, 2017, 2023}:
             self._add_new_years_day("Año nuevo")
 
-        if year not in {2013, 2019}:
+        if self._year not in {2013, 2019}:
             self._add_epiphany_day("Epifanía del Señor")
 
         self._add_good_friday("Viernes Santo")
 
-        if year not in {2011, 2016, 2022}:
+        if self._year not in {2011, 2016, 2022}:
             self._add_labor_day("Fiesta del Trabajo")
 
-        if year not in {2010, 2021}:
+        if self._year not in {2010, 2021}:
             self._add_assumption_of_mary_day("Asunción de la Virgen")
 
-        if year != 2014:
+        if self._year != 2014:
             self._add_holiday_oct_12("Fiesta Nacional de España")
 
-        if year not in {2015, 2020}:
+        if self._year not in {2015, 2020}:
             self._add_all_saints_day("Todos los Santos")
 
             self._add_holiday_dec_6("Día de la Constitución Española")
 
-        if year not in {2013, 2019, 2024}:
+        if self._year not in {2013, 2019, 2024}:
             self._add_immaculate_conception_day("Inmaculada Concepción")
 
-        if year not in {2011, 2016, 2022}:
+        if self._year not in {2011, 2016, 2022}:
             self._add_christmas_day("Natividad del Señor")
 
     def _populate_subdiv_an_public_holidays(self):

--- a/holidays/countries/sweden.py
+++ b/holidays/countries/sweden.py
@@ -46,16 +46,14 @@ class Sweden(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("Nyårsdagen"))
 
         # Epiphany.
         self._add_epiphany_day(tr("Trettondedag jul"))
 
-        if year <= 1953:
+        if self._year <= 1953:
             # Feast of the Annunciation.
             self._add_holiday_mar_25(tr("Jungfru Marie bebådelsedag"))
 
@@ -69,7 +67,7 @@ class Sweden(HolidayBase, ChristianHolidays, InternationalHolidays):
         self._add_easter_monday(tr("Annandag påsk"))
 
         # Source: https://sv.wikipedia.org/wiki/F%C3%B6rsta_maj
-        if year >= 1939:
+        if self._year >= 1939:
             # May Day.
             self._add_labor_day(tr("Första maj"))
 
@@ -77,14 +75,14 @@ class Sweden(HolidayBase, ChristianHolidays, InternationalHolidays):
         self._add_ascension_thursday(tr("Kristi himmelsfärdsdag"))
 
         # Source: https://sv.wikipedia.org/wiki/Sveriges_nationaldag
-        if year >= 2005:
+        if self._year >= 2005:
             # National Day of Sweden.
             self._add_holiday_jun_6(tr("Sveriges nationaldag"))
 
         # Whit Sunday.
         self._add_whit_sunday(tr("Pingstdagen"))
 
-        if year <= 2004:
+        if self._year <= 2004:
             # Whit Monday.
             self._add_whit_monday(tr("Annandag pingst"))
 
@@ -97,7 +95,7 @@ class Sweden(HolidayBase, ChristianHolidays, InternationalHolidays):
         name = tr("Midsommarafton")
         dt = (
             self._add_holiday_1st_fri_from_jun_19(name)
-            if year >= 1953
+            if self._year >= 1953
             else self._add_holiday_jun_23(name)
         )
 
@@ -121,7 +119,7 @@ class Sweden(HolidayBase, ChristianHolidays, InternationalHolidays):
 
         # Optionally add all Sundays of the year.
         if self.include_sundays:
-            for dt in _get_all_sundays(year):
+            for dt in _get_all_sundays(self._year):
                 # Sunday.
                 self._add_holiday(tr("Söndag"), dt)
 

--- a/holidays/countries/switzerland.py
+++ b/holidays/countries/switzerland.py
@@ -55,9 +55,7 @@ class Switzerland(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("Neujahrestag"))
 
@@ -70,7 +68,7 @@ class Switzerland(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Whit Sunday.
         self._add_whit_sunday(tr("Pfingsten"))
 
-        if year >= 1291:
+        if self._year >= 1291:
             # National Day.
             self._add_holiday_aug_1(tr("Nationalfeiertag"))
 

--- a/holidays/countries/taiwan.py
+++ b/holidays/countries/taiwan.py
@@ -38,10 +38,9 @@ class Taiwan(ObservedHolidayBase, ChineseCalendarHolidays, InternationalHolidays
         kwargs.setdefault("observed_since", 2015)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1911:
+    def _populate_public_holidays(self):
+        if self._year <= 1911:
             return None
-        super()._populate(year)
 
         dts_observed = set()
 
@@ -56,7 +55,7 @@ class Taiwan(ObservedHolidayBase, ChineseCalendarHolidays, InternationalHolidays
         name = "Lunar New Year Holiday"
         self._add_chinese_new_years_day_two(name)
         self._add_chinese_new_years_day_three(name)
-        if self.observed and year >= 2015:
+        if self.observed and self._year >= 2015:
             if self._is_monday(dt):
                 self._add_chinese_new_years_day_four(name)
             elif self._is_thursday(dt):
@@ -66,15 +65,15 @@ class Taiwan(ObservedHolidayBase, ChineseCalendarHolidays, InternationalHolidays
                 self._add_chinese_new_years_day_five(name)
 
         # Peace Memorial Day.
-        if year >= 1997:
+        if self._year >= 1997:
             dts_observed.add(self._add_holiday_feb_28("Peace Memorial Day"))
 
         # Children's Day.
-        if 1990 <= year <= 1999 or year >= 2011:
+        if 1990 <= self._year <= 1999 or self._year >= 2011:
             dts_observed.add(self._add_holiday_apr_4("Children's Day"))
 
         # Tomb Sweeping Day.
-        if year >= 1972:
+        if self._year >= 1972:
             dts_observed.add(self._add_qingming_festival("Tomb Sweeping Day"))
 
         # Dragon Boat Festival.

--- a/holidays/countries/tunisia.py
+++ b/holidays/countries/tunisia.py
@@ -17,16 +17,7 @@ from holidays.holiday_base import HolidayBase
 
 
 class Tunisia(HolidayBase, InternationalHolidays, IslamicHolidays):
-    """
-    Holidays here are estimates, it is common for the day to be pushed
-    if falls in a weekend, although not a rule that can be implemented.
-    Holidays after 2020: the following four moving date holidays whose exact
-    date is announced yearly are estimated (and so denoted):
-    - Eid El Fetr
-    - Eid El Adha
-    - Arafat Day
-    - Moulad El Naby
-    """
+    """Tunisia holidays."""
 
     country = "TN"
     default_language = "ar"
@@ -39,9 +30,7 @@ class Tunisia(HolidayBase, InternationalHolidays, IslamicHolidays):
         IslamicHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("رأس السنة الميلادية"))
 

--- a/holidays/countries/ukraine.py
+++ b/holidays/countries/ukraine.py
@@ -62,18 +62,17 @@ class Ukraine(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Sta
         # https://zakon.rada.gov.ua/laws/show/576-14
         return date(1995, JAN, 27) <= dt <= date(1998, JAN, 9) or dt >= date(1999, APR, 23)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # The current set of holidays came into force in 1991
-        if year <= 1990:
+        if self._year <= 1990:
             return None
 
         # There is no holidays in Ukraine during the period of martial law
         # https://zakon.rada.gov.ua/laws/show/2136-20#n26
         # law is in force from March 15, 2022
-        if year >= 2023:
+        if self._year >= 2023:
             return None
 
-        super()._populate(year)
         dts_observed = set()
 
         # New Year's Day.
@@ -89,8 +88,8 @@ class Ukraine(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Sta
 
         # There is no holidays from March 15, 2022
         # https://zakon.rada.gov.ua/laws/show/2136-20#n26
-        if year <= 2021:
-            if year >= 1992:
+        if self._year <= 2021:
+            if self._year >= 1992:
                 # Easter Sunday (Pascha).
                 dts_observed.add(self._add_easter_sunday(tr("Великдень (Пасха)")))
 
@@ -100,51 +99,51 @@ class Ukraine(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Sta
             name = (
                 # Labour Day.
                 tr("День праці")
-                if year >= 2018
+                if self._year >= 2018
                 # International Workers' Solidarity Day.
                 else tr("День міжнародної солідарності трудящих")
             )
             dts_observed.add(self._add_labor_day(name))
-            if year <= 2017:
+            if self._year <= 2017:
                 dts_observed.add(self._add_labor_day_two(name))
 
             name = (
                 # Day of Victory over Nazism in World War II (Victory Day).
                 tr("День перемоги над нацизмом у Другій світовій війні (День перемоги)")
-                if year >= 2016
+                if self._year >= 2016
                 # Victory Day.
                 else tr("День перемоги")
             )
             dts_observed.add(self._add_world_war_two_victory_day(name))
 
-            if year >= 1997:
+            if self._year >= 1997:
                 # Day of the Constitution of Ukraine.
                 dts_observed.add(self._add_holiday_jun_28(tr("День Конституції України")))
 
             # Independence Day.
             name = tr("День незалежності України")
-            if year >= 1992:
+            if self._year >= 1992:
                 dts_observed.add(self._add_holiday_aug_24(name))
             else:
                 self._add_holiday_jul_16(name)
 
-            if year >= 2015:
+            if self._year >= 2015:
                 name = (
                     # Day of defenders of Ukraine.
                     tr("День захисників і захисниць України")
-                    if year >= 2021
+                    if self._year >= 2021
                     # Defender of Ukraine Day.
                     else tr("День захисника України")
                 )
                 dts_observed.add(self._add_holiday_oct_14(name))
 
-            if year <= 1999:
+            if self._year <= 1999:
                 # Anniversary of the Great October Socialist Revolution.
                 name = tr("Річниця Великої Жовтневої соціалістичної революції")
                 dts_observed.add(self._add_holiday_nov_7(name))
                 dts_observed.add(self._add_holiday_nov_8(name))
 
-            if year >= 2017:
+            if self._year >= 2017:
                 dts_observed.add(
                     self._add_christmas_day(
                         # Christmas (Gregorian calendar).

--- a/holidays/countries/united_arab_emirates.py
+++ b/holidays/countries/united_arab_emirates.py
@@ -52,16 +52,14 @@ class UnitedArabEmirates(HolidayBase, InternationalHolidays, IslamicHolidays):
         IslamicHolidays.__init__(self, cls=UnitedArabEmiratesIslamicHolidays)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day.
         self._add_new_years_day(tr("رأس السنة الميلادية"))
 
-        if year >= 2015:
+        if self._year >= 2015:
             # Commemoration Day.
             name = tr("يوم الشهيد")
-            if year >= 2019:
+            if self._year >= 2019:
                 self._add_holiday_dec_1(name)
             else:
                 self._add_holiday_nov_30(name)
@@ -89,11 +87,11 @@ class UnitedArabEmirates(HolidayBase, InternationalHolidays, IslamicHolidays):
         self._add_islamic_new_year_day(tr("رأس السنة الهجرية"))
 
         # Leilat al-Miraj.
-        if year <= 2018:  # The UAE government removed this starting 2019.
+        if self._year <= 2018:  # The UAE government removed this starting 2019.
             self._add_isra_and_miraj_day(tr("ليلة المعراج"))
 
         # Prophet Muhammad's Birthday.
-        if year <= 2019:  # The UAE government removed this starting 2020.
+        if self._year <= 2019:  # The UAE government removed this starting 2020.
             self._add_mawlid_day(tr("عيد المولد النبوي"))
 
 

--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -53,30 +53,28 @@ class UnitedKingdom(ObservedHolidayBase, ChristianHolidays, InternationalHoliday
         kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year: int) -> None:
-        super()._populate(year)
-
+    def _populate_public_holidays(self) -> None:
         # Good Friday
         self._add_good_friday("Good Friday")
 
         # May Day bank holiday (first Monday in May)
-        if year >= 1978:
+        if self._year >= 1978:
             name = "May Day"
-            if year in {1995, 2020}:
+            if self._year in {1995, 2020}:
                 self._add_holiday_may_8(name)
             else:
                 self._add_holiday_1st_mon_of_may(name)
 
         # Spring bank holiday (last Monday in May)
-        if year >= 1971:
+        if self._year >= 1971:
             spring_bank_dates = {
                 2002: (JUN, 4),
                 2012: (JUN, 4),
                 2022: (JUN, 2),
             }
             name = "Spring Bank Holiday"
-            if year in spring_bank_dates:
-                self._add_holiday(name, spring_bank_dates[year])
+            if self._year in spring_bank_dates:
+                self._add_holiday(name, spring_bank_dates[self._year])
             else:
                 self._add_holiday_last_mon_of_may(name)
 

--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -115,49 +115,47 @@ class UnitedStates(ObservedHolidayBase, ChristianHolidays, InternationalHolidays
         kwargs.setdefault("observed_rule", SAT_TO_PREV_FRI + SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year's Day
-        if year >= 1871:
+        if self._year >= 1871:
             name = "New Year's Day"
             self._add_observed(self._add_new_years_day(name))
             self._add_observed(self._next_year_new_years_day, name=name)
 
         # Memorial Day
-        if year >= 1888:
+        if self._year >= 1888:
             name = "Memorial Day"
-            if year >= 1971:
+            if self._year >= 1971:
                 self._add_holiday_last_mon_of_may(name)
             else:
                 self._add_holiday_may_30(name)
 
         # Juneteenth Day
-        if year >= 2021:
+        if self._year >= 2021:
             self._add_observed(self._add_holiday_jun_19("Juneteenth National Independence Day"))
 
         # Independence Day
-        if year >= 1871:
+        if self._year >= 1871:
             self._add_observed(self._add_holiday_jul_4("Independence Day"))
 
         # Labor Day
-        if year >= 1894:
+        if self._year >= 1894:
             self._add_holiday_1st_mon_of_sep("Labor Day")
 
         # Veterans Day
-        if year >= 1938:
-            name = "Veterans Day" if year >= 1954 else "Armistice Day"
-            if 1971 <= year <= 1977:
+        if self._year >= 1938:
+            name = "Veterans Day" if self._year >= 1954 else "Armistice Day"
+            if 1971 <= self._year <= 1977:
                 self._add_holiday_4th_mon_of_oct(name)
             else:
                 self._add_observed(self._add_remembrance_day(name))
 
         # Thanksgiving
-        if year >= 1871:
+        if self._year >= 1871:
             self._add_holiday_4th_thu_of_nov("Thanksgiving")
 
         # Christmas Day
-        if year >= 1871:
+        if self._year >= 1871:
             self._add_observed(self._add_christmas_day("Christmas Day"))
 
     def _add_christmas_eve_holiday(self):

--- a/holidays/countries/united_states_minor_outlying_islands.py
+++ b/holidays/countries/united_states_minor_outlying_islands.py
@@ -20,9 +20,9 @@ class HolidaysUM(US):
     country = "UM"
     subdivisions = ()  # Override US subdivisions.
 
-    def _populate(self, year: int) -> None:
+    def _populate_public_holidays(self) -> None:
         self.subdiv = "UM"
-        super()._populate(year)
+        super()._populate_public_holidays()
 
 
 class UM(HolidaysUM):

--- a/holidays/countries/united_states_virgin_islands.py
+++ b/holidays/countries/united_states_virgin_islands.py
@@ -20,9 +20,9 @@ class HolidaysVI(US):
     country = "VI"
     subdivisions = ()  # Override US subdivisions.
 
-    def _populate(self, year: int) -> None:
+    def _populate_public_holidays(self) -> None:
         self.subdiv = "VI"
-        super()._populate(year)
+        super()._populate_public_holidays()
 
 
 class VI(HolidaysVI):

--- a/holidays/countries/uzbekistan.py
+++ b/holidays/countries/uzbekistan.py
@@ -25,9 +25,7 @@ class Uzbekistan(HolidayBase, InternationalHolidays, IslamicHolidays):
         IslamicHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         # New Year
         self._add_new_years_day("New Year")
 

--- a/holidays/countries/vanuatu.py
+++ b/holidays/countries/vanuatu.py
@@ -31,17 +31,15 @@ class Vanuatu(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Sta
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # On 30 July 1980, Vanuatu gained independence from Britain and France.
-        if year <= 1980:
+        if self._year <= 1980:
             return None
-
-        super()._populate(year)
 
         # New Years Day.
         self._add_observed(self._add_new_years_day("New Year's Day"))
 
-        if year >= 1999:
+        if self._year >= 1999:
             # Father Lini Day.
             self._add_observed(self._add_holiday_feb_21("Father Lini Day"))
 

--- a/holidays/countries/vatican_city.py
+++ b/holidays/countries/vatican_city.py
@@ -27,10 +27,9 @@ class VaticanCity(HolidayBase, ChristianHolidays):
         ChristianHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year: int) -> None:
-        if year <= 1928:
+    def _populate_public_holidays(self) -> None:
+        if self._year <= 1928:
             return None
-        super()._populate(year)
 
         # Solemnity of Mary Day.
         # This is supposedly the same as International New Year.
@@ -44,12 +43,12 @@ class VaticanCity(HolidayBase, ChristianHolidays):
         # Lateran Treaty Day.
         self._add_holiday_feb_11("Lateran Treaty Day")
 
-        if year >= 1978:
+        if self._year >= 1978:
             name = "Anniversary of the Election of the Holy Father"
-            if year >= 2013:
+            if self._year >= 2013:
                 # Anniversary of the election of Pope Francis.
                 self._add_holiday_mar_13(name)
-            elif year >= 2005:
+            elif self._year >= 2005:
                 # Anniversary of the election of Pope Benedict XVI.
                 self._add_holiday_apr_19(name)
             else:
@@ -67,18 +66,18 @@ class VaticanCity(HolidayBase, ChristianHolidays):
         # Easter Monday.
         self._add_easter_monday("Easter Monday")
 
-        if year >= 2013:
+        if self._year >= 2013:
             # Name day for the civilian name of Pope Francis
             # (Jorge Mario Bergoglio)
             # Saint George's Day.
             self._add_saint_georges_day("Saint George's Day")
 
-        if year >= 1955:
+        if self._year >= 1955:
             # Saint Joseph the Worker's Day.
             # Created in response to May Day holidays by Pope Pius XII in 1955.
             self._add_holiday_may_1("Saint Joseph the Worker's Day")
 
-        if year <= 2009:
+        if self._year <= 2009:
             # Ascension of Christ.
             self._add_ascension_thursday("Ascension of Christ")
 
@@ -97,7 +96,7 @@ class VaticanCity(HolidayBase, ChristianHolidays):
         # All Saints' Day.
         self._add_all_saints_day("All Saints' Day")
 
-        if 1978 <= year <= 2004:
+        if 1978 <= self._year <= 2004:
             # Name day for the civilian name of Pope John Paul II
             # (Karol Józef Wojtyła)
             # Saint Charles Borromeo Day.

--- a/holidays/countries/venezuela.py
+++ b/holidays/countries/venezuela.py
@@ -29,9 +29,7 @@ class Venezuela(HolidayBase, ChristianHolidays, InternationalHolidays):
         InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
-
+    def _populate_public_holidays(self):
         """
         Overview: https://dias-festivos.eu/dias-festivos/venezuela/#
         Various decrees about holidays:
@@ -59,41 +57,41 @@ class Venezuela(HolidayBase, ChristianHolidays, InternationalHolidays):
         self._add_good_friday(tr("Viernes Santo"))
 
         # Note: not sure about the start year, but this event happened in 1811
-        if year >= 1811:
+        if self._year >= 1811:
             # Declaration of Independence.
             self._add_holiday_apr_19(tr("Declaración de la Independencia"))
 
         # https://bit.ly/3B4Xd1L
-        if year >= 1946:
+        if self._year >= 1946:
             # International Worker's Day.
             self._add_labor_day(tr("Dia Mundial del Trabajador"))
 
         # Note: not sure about the start year, but this event happened in 1824
-        if year >= 1971 or 1824 <= year <= 1917:
+        if self._year >= 1971 or 1824 <= self._year <= 1917:
             # Battle of Carabobo.
             self._add_holiday_jun_24(tr("Batalla de Carabobo"))
 
         # Note: not sure about the start year, but this event happened in 1811
-        if year >= 1811:
+        if self._year >= 1811:
             # Independence Day.
             self._add_holiday_jul_5(tr("Día de la Independencia"))
 
-        if year >= 1918:
+        if self._year >= 1918:
             # Birthday of Simon Bolivar.
             self._add_holiday_jul_24(tr("Natalicio de Simón Bolívar"))
 
-        if year >= 1921:
+        if self._year >= 1921:
             self._add_columbus_day(
                 # Day of Indigenous Resistance.
                 tr("Día de la Resistencia Indígena")
-                if year >= 2002
+                if self._year >= 2002
                 # Columbus Day.
                 else tr("Día de la Raza")
             )
 
         # Note: not sure about the start year nor the reason this was
         # Note: celebrated; the historical records are unclear
-        if 1909 <= year <= 1917:
+        if 1909 <= self._year <= 1917:
             # Unknown Holiday.
             self._add_holiday_oct_28(tr("Día Festivo Desconocido"))
 

--- a/holidays/countries/vietnam.py
+++ b/holidays/countries/vietnam.py
@@ -29,8 +29,7 @@ class Vietnam(ObservedHolidayBase, ChineseCalendarHolidays, InternationalHoliday
         kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_WORKDAY)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        super()._populate(year)
+    def _populate_public_holidays(self):
         dts_observed = set()
 
         # New Year's Day
@@ -46,7 +45,7 @@ class Vietnam(ObservedHolidayBase, ChineseCalendarHolidays, InternationalHoliday
 
         # Vietnamese Kings' Commemoration Day
         # https://en.wikipedia.org/wiki/H%C3%B9ng_Kings%27_Festival
-        if year >= 2007:
+        if self._year >= 2007:
             dts_observed.add(self._add_hung_kings_day("Hung Kings Commemoration Day"))
 
         # Liberation Day/Reunification Day

--- a/holidays/countries/zambia.py
+++ b/holidays/countries/zambia.py
@@ -32,17 +32,15 @@ class Zambia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
+    def _populate_public_holidays(self):
         # Observed since 1965
-        if year <= 1964:
+        if self._year <= 1964:
             return None
-
-        super()._populate(year)
 
         # New Year's Day.
         self._add_observed(self._add_new_years_day("New Year's Day"))
 
-        if year >= 1991:
+        if self._year >= 1991:
             self._add_observed(
                 # International Women's Day.
                 self._add_womens_day("International Women's Day")
@@ -60,7 +58,7 @@ class Zambia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         # Easter Monday.
         self._add_easter_monday("Easter Monday")
 
-        if year >= 2022:
+        if self._year >= 2022:
             # Kenneth Kaunda Day.
             self._add_observed(self._add_holiday_apr_28("Kenneth Kaunda Day"))
 
@@ -79,7 +77,7 @@ class Zambia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         # Farmers' Day.
         self._add_holiday_1st_mon_of_aug("Farmers' Day")
 
-        if year >= 2015:
+        if self._year >= 2015:
             # National Prayer Day.
             self._add_observed(self._add_holiday_oct_18("National Prayer Day"))
 

--- a/holidays/countries/zimbabwe.py
+++ b/holidays/countries/zimbabwe.py
@@ -28,16 +28,14 @@ class Zimbabwe(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         kwargs.setdefault("observed_rule", SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _populate(self, year):
-        if year <= 1987:
+    def _populate_public_holidays(self):
+        if self._year <= 1987:
             return None
-
-        super()._populate(year)
 
         # New Year's Day.
         self._add_observed(self._add_new_years_day("New Year's Day"))
 
-        if year >= 2018:
+        if self._year >= 2018:
             self._add_observed(
                 # Robert Gabriel Mugabe National Youth Day.
                 self._add_holiday_feb_21("Robert Gabriel Mugabe National Youth Day")


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

Extend native holiday categories support:
  - Migrate HolidayBase::_populate to HolidayBase::_populate_public_holidays
  - Use self._year instead of year


## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/beta/docs/source
