### PR TITLE
Use common abbreviations for Austrian states.

### DIFF
--- a/holidays/countries/austria.py
+++ b/holidays/countries/austria.py
@@ -4,7 +4,8 @@
 #  specific sets of holidays on the fly. It aims to make determining whether a
 #  specific date is a holiday as fast and flexible as possible.
 #
-#  Authors: dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#  Authors: Stephan Helma <s.p.helma@gmx.net> (c) 2024
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
 #           ryanss <ryanssdev@icloud.com> (c) 2014-2017
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
@@ -21,7 +22,8 @@ class Austria(HolidayBase, ChristianHolidays, InternationalHolidays):
     default_language = "de"
     supported_categories = (BANK, PUBLIC)
     supported_languages = ("de", "en_US", "uk")
-    subdivisions = ("1", "2", "3", "4", "5", "6", "7", "8", "9")
+    subdivisions = ("B", "K", "N", "O", "S", "St", "T", "V", "W")
+    _deprecated_subdivisions = ("1", "2", "3", "4", "5", "6", "7", "8", "9")
 
     def __init__(self, *args, **kwargs) -> None:
         ChristianHolidays.__init__(self)
@@ -29,7 +31,7 @@ class Austria(HolidayBase, ChristianHolidays, InternationalHolidays):
 
         # Set the default subdivision.
         if not kwargs.get("subdiv", kwargs.get("state")):
-            kwargs["subdiv"] = "9"
+            kwargs["subdiv"] = "W"
 
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Commit
https://github.com/vacanza/python-holidays/commit/4342d28ff0f6d6a63aff433c72b80d33589991f7 uses the numbers 1-9 for the nine states in Austria, but actually no one in Austria uses these numbers. This commit uses the common character codes (B, K, N, O, S, St, T, V, W) with the same default (9 and W) and adds the numbers as deprecated subdivisions. (See also #284)

Comment https://github.com/vacanza/python-holidays/issues/284#issuecomment-584852192 reasons, that the numbers were used to keep it consistent with the other countries. Looking at https://python-holidays.readthedocs.io/en/latest/index.html#available-countries numbers are nowadays very rarely used for subdivisions.

It is expected for the impact to be negligible, because none of these subdivisions actually does have an effect on the list of holidays.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I've run `make pre-commit`, it didn't generate any changes
- [ ] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/beta/docs/source
