### PR TITLE
Fully replace black with ruff, restore 99 char limit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,6 @@ repos:
         exclude_types:
           - rst
 
-  - repo: https://github.com/python/black
-    rev: 23.12.1
-    hooks:
-      - id: black
-        exclude: ^(docs)
-        language_version: python3
-
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,6 @@ Documentation = "https://python-holidays.readthedocs.io/en/latest/"
 Changelog = "https://github.com/vacanza/python-holidays/releases"
 Downloads = "https://pypi.org/project/holidays/"
 
-[tool.black]
-line-length = 99
-target-version = ["py38", "py39", "py310", "py311"]
-
 [tool.coverage.run]
 branch = true
 omit = ["scripts/*", "setup.py", "tests/*"]
@@ -49,7 +45,6 @@ multi_line_output = 3
 no_inline_sort = true
 profile = "black"
 skip = ["docs"]
-
 
 [tool.mypy]
 strict = false
@@ -65,6 +60,15 @@ disable_error_code = "attr-defined"
 [tool.rstcheck]
 ignore_directives = ["automodule", "autosummary"]
 ignore_languages = ["python"]
+
+[tool.ruff]
+line-length = 99
+# only minimum supported version, see https://github.com/astral-sh/ruff/issues/2519
+target-version = "py38"
+
+[tool.ruff.lint]
+# Skip Whitespace before ':' (E203).
+ignore = ["E203"]
 
 [tool.setuptools.dynamic]
 version = {attr = "holidays.__version__"}


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

This PR fully replace the existing `black` with `ruff` as intended in #1671 .

This also restores line length limit to 99 as per outlined in #1297 .

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/beta/docs/source
