### PR TITLE
Update Portugal: fix Carnival holiday date

### DIFF
--- a/holidays/countries/portugal.py
+++ b/holidays/countries/portugal.py
@@ -145,7 +145,7 @@ class Portugal(HolidayBase, ChristianHolidays, InternationalHolidays):
         # - get Holidays that occur on Thursday and add Friday (+1 day)
 
         # Carnival.
-        self._add_carnival_monday(tr("Carnaval"))
+        self._add_carnival_tuesday(tr("Carnaval"))
 
         # St. Anthony's Day.
         self._add_holiday_jun_13(tr("Dia de Santo António"))

--- a/tests/countries/test_portugal.py
+++ b/tests/countries/test_portugal.py
@@ -153,17 +153,17 @@ class TestPortugal(CommonCountryTests, TestCase):
         holidays = Portugal(categories=OPTIONAL, years=range(2017, 2020))
         self.assertHoliday(
             holidays,
-            "2017-02-27",
+            "2017-02-28",
             "2017-06-13",
             "2017-12-24",
             "2017-12-26",
             "2017-12-31",
-            "2018-02-12",
+            "2018-02-13",
             "2018-06-13",
             "2018-12-24",
             "2018-12-26",
             "2018-12-31",
-            "2019-03-04",
+            "2019-03-05",
             "2019-06-13",
             "2019-12-24",
             "2019-12-26",
@@ -243,7 +243,7 @@ class TestPortugal(CommonCountryTests, TestCase):
     def test_l10n_default(self):
         self.assertLocalizedHolidays(
             ("2018-01-01", "Ano Novo"),
-            ("2018-02-12", "Carnaval"),
+            ("2018-02-13", "Carnaval"),
             ("2018-03-30", "Sexta-feira Santa"),
             ("2018-04-01", "Páscoa"),
             ("2018-04-25", "Dia da Liberdade"),
@@ -266,7 +266,7 @@ class TestPortugal(CommonCountryTests, TestCase):
         self.assertLocalizedHolidays(
             "en_US",
             ("2018-01-01", "New Year's Day"),
-            ("2018-02-12", "Carnival"),
+            ("2018-02-13", "Carnival"),
             ("2018-03-30", "Good Friday"),
             ("2018-04-01", "Easter Sunday"),
             ("2018-04-25", "Freedom Day"),
@@ -289,7 +289,7 @@ class TestPortugal(CommonCountryTests, TestCase):
         self.assertLocalizedHolidays(
             "uk",
             ("2022-01-01", "Новий рік"),
-            ("2022-02-28", "Карнавал"),
+            ("2022-03-01", "Карнавал"),
             ("2022-04-15", "Страсна пʼятниця"),
             ("2022-04-17", "Великдень"),
             ("2022-04-25", "День Свободи"),


### PR DESCRIPTION
## Proposed change

This aims to fix an issue with the current weekday of the Carnival holiday in Portugal.
It was set to happen on a Monday when it's always been a Tuesday.

There's not an official government document because Carnival is an optional holiday, there is however a Wikipedia [entry](https://pt.wikipedia.org/wiki/Feriados_em_Portugal) with this information.

Closes #1692.

## Type of change

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

I've ran `make pre-commit` but got the following error message:
<img width="1510" alt="Captura de ecrã 2024-02-19, às 11 07 40" src="https://github.com/vacanza/python-holidays/assets/16542680/42701c60-7b5a-4862-baee-8a78de4706a3">

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/beta/docs/source
