### PR TITLE
Update tests: use assertIsInstance

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -41,9 +41,9 @@ class TestEntityLoader(TestCase):
                 self.assertIsNotNone(loader_cls, entity)
                 self.assertIsNotNone(module_cls, entity)
                 self.assertEqual(countries_cls, module_cls)
-                self.assertTrue(isinstance(loader_cls, registry.EntityLoader))
-                self.assertTrue(isinstance(loader_cls(), countries_cls))
-                self.assertTrue(isinstance(loader_cls(), module_cls))
+                self.assertIsInstance(loader_cls, registry.EntityLoader)
+                self.assertIsInstance(loader_cls(), countries_cls)
+                self.assertIsInstance(loader_cls(), module_cls)
 
                 loader_entities.add(loader_cls.__name__)
 
@@ -82,9 +82,9 @@ class TestEntityLoader(TestCase):
                 self.assertIsNotNone(loader_cls, entity)
                 self.assertIsNotNone(module_cls, entity)
                 self.assertEqual(financial_cls, module_cls)
-                self.assertTrue(isinstance(loader_cls, registry.EntityLoader))
-                self.assertTrue(isinstance(loader_cls(), financial_cls))
-                self.assertTrue(isinstance(loader_cls(), module_cls))
+                self.assertIsInstance(loader_cls, registry.EntityLoader)
+                self.assertIsInstance(loader_cls(), financial_cls)
+                self.assertIsInstance(loader_cls(), module_cls)
 
                 loader_entities.add(loader_cls.__name__)
 
@@ -115,7 +115,7 @@ class TestEntityLoader(TestCase):
             return SubClass()
 
         for cls in (holidays.UnitedStates, holidays.US, holidays.USA):
-            self.assertTrue(isinstance(cls, holidays.registry.EntityLoader))
+            self.assertIsInstance(cls, holidays.registry.EntityLoader)
             with self.assertRaises(TypeError):
                 create_instance(cls)
 
@@ -124,4 +124,4 @@ class TestEntityLoader(TestCase):
             holidays.countries.US,
             holidays.countries.USA,
         ):
-            self.assertTrue(isinstance(create_instance(cls), holidays.countries.UnitedStates))
+            self.assertIsInstance(create_instance(cls), holidays.countries.UnitedStates)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -177,10 +177,7 @@ class TestListLocalizedEntities(unittest.TestCase):
             )
 
             if expected_languages:
-                self.assertTrue(
-                    isinstance(expected_languages, list),
-                    entity_code,
-                )
+                self.assertIsInstance(expected_languages, list, entity_code)
                 self.assertIn(
                     entity.default_language,
                     expected_languages,
@@ -212,7 +209,7 @@ class TestListSupportedEntities(unittest.TestCase):
 
         us_subdivisions = supported_countries["US"]
         self.assertIn("CA", us_subdivisions)
-        self.assertTrue(isinstance(us_subdivisions, list))
+        self.assertIsInstance(us_subdivisions, list)
 
         countries_files = [
             path for path in Path("holidays/countries").glob("*.py") if path.stem != "__init__"
@@ -229,7 +226,7 @@ class TestListSupportedEntities(unittest.TestCase):
         self.assertIn("NYSE", supported_financial)
 
         nyse = supported_financial["NYSE"]
-        self.assertTrue(isinstance(nyse, list))
+        self.assertIsInstance(nyse, list)
 
         financial_files = [
             path for path in Path("holidays/financial").glob("*.py") if path.stem != "__init__"


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Use `assertIsInstance` instead of `assertTrue(isinstance...`)

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
