### PR TITLE
Fix Romanian language strings: replace U+015F with proper U+0219

### DIFF
--- a/holidays/countries/moldova.py
+++ b/holidays/countries/moldova.py
@@ -42,10 +42,10 @@ class Moldova(HolidayBase, ChristianHolidays, InternationalHolidays):
 
         name = (
             # Christmas Day (by old style).
-            tr("Naşterea lui Iisus Hristos (Crăciunul pe stil vechi)")
+            tr("Nașterea lui Iisus Hristos (Crăciunul pe stil vechi)")
             if self._year >= 2014
             # Christmas Day.
-            else tr("Naşterea lui Iisus Hristos (Crăciunul)")
+            else tr("Nașterea lui Iisus Hristos (Crăciunul)")
         )
         self._add_christmas_day(name)
         self._add_christmas_day_two(name)
@@ -54,12 +54,12 @@ class Moldova(HolidayBase, ChristianHolidays, InternationalHolidays):
         self._add_womens_day(tr("Ziua internatională a femeii"))
 
         # Easter.
-        name = tr("Paştele")
+        name = tr("Paștele")
         self._add_easter_sunday(name)
         self._add_easter_monday(name)
 
         # Day of Rejoicing.
-        self._add_holiday(tr("Paştele blajinilor"), self._easter_sunday + td(days=+8))
+        self._add_holiday(tr("Paștele blajinilor"), self._easter_sunday + td(days=+8))
 
         # International Workers' Solidarity Day.
         self._add_labor_day(tr("Ziua internaţională a solidarităţii oamenilor muncii"))
@@ -67,7 +67,7 @@ class Moldova(HolidayBase, ChristianHolidays, InternationalHolidays):
         may_9 = self._add_world_war_two_victory_day(
             # Victory Day and Commemoration of the heroes fallen for
             # Independence of Fatherland.
-            tr("Ziua Victoriei şi a comemorării eroilor căzuţi pentru Independenţa Patriei")
+            tr("Ziua Victoriei și a comemorării eroilor căzuţi pentru Independenţa Patriei")
         )
 
         if self._year >= 2017:
@@ -87,7 +87,7 @@ class Moldova(HolidayBase, ChristianHolidays, InternationalHolidays):
         if self._year >= 2013:
             self._add_christmas_day(
                 # Christmas Day (by new style).
-                tr("Naşterea lui Iisus Hristos (Crăciunul pe stil nou)"),
+                tr("Nașterea lui Iisus Hristos (Crăciunul pe stil nou)"),
                 GREGORIAN_CALENDAR,
             )
 

--- a/holidays/locale/en_US/LC_MESSAGES/MD.po
+++ b/holidays/locale/en_US/LC_MESSAGES/MD.po
@@ -3,9 +3,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Python Holidays 0.22\n"
+"Project-Id-Version: Python Holidays 0.46\n"
 "POT-Creation-Date: 2023-03-22 21:58+0200\n"
-"PO-Revision-Date: 2024-01-05 12:40+0200\n"
+"PO-Revision-Date: 2024-03-20 21:12+0200\n"
 "Last-Translator: ~Jhellico <jhellico@gmail.com>\n"
 "Language-Team: Python Holidays localization team\n"
 "Language: en_US\n"
@@ -21,11 +21,11 @@ msgid "Anul Nou"
 msgstr "New Year's Day"
 
 #. Christmas Day (by old style).
-msgid "Naşterea lui Iisus Hristos (Crăciunul pe stil vechi)"
+msgid "Nașterea lui Iisus Hristos (Crăciunul pe stil vechi)"
 msgstr "Christmas Day (by old style)"
 
 #. Christmas Day.
-msgid "Naşterea lui Iisus Hristos (Crăciunul)"
+msgid "Nașterea lui Iisus Hristos (Crăciunul)"
 msgstr "Christmas Day"
 
 #. International Women's Day.
@@ -33,11 +33,11 @@ msgid "Ziua internatională a femeii"
 msgstr "International Women's Day"
 
 #. Easter.
-msgid "Paştele"
+msgid "Paștele"
 msgstr "Easter"
 
 #. Day of Rejoicing.
-msgid "Paştele blajinilor"
+msgid "Paștele blajinilor"
 msgstr "Day of Rejoicing"
 
 #. International Workers' Solidarity Day.
@@ -47,7 +47,7 @@ msgstr "International Workers' Solidarity Day"
 #. Victory Day and Commemoration of the heroes fallen for Independence of
 #. Fatherland.
 msgid ""
-"Ziua Victoriei şi a comemorării eroilor căzuţi pentru Independenţa Patriei"
+"Ziua Victoriei și a comemorării eroilor căzuţi pentru Independenţa Patriei"
 msgstr ""
 "Victory Day and Commemoration of the heroes fallen for Independence of "
 "Fatherland"
@@ -69,5 +69,5 @@ msgid "Limba noastră"
 msgstr "National Language Day"
 
 #. Christmas Day (by new style).
-msgid "Naşterea lui Iisus Hristos (Crăciunul pe stil nou)"
+msgid "Nașterea lui Iisus Hristos (Crăciunul pe stil nou)"
 msgstr "Christmas Day (by new style)"

--- a/holidays/locale/ro/LC_MESSAGES/MD.po
+++ b/holidays/locale/ro/LC_MESSAGES/MD.po
@@ -3,9 +3,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Python Holidays 0.22\n"
+"Project-Id-Version: Python Holidays 0.46\n"
 "POT-Creation-Date: 2023-03-22 21:58+0200\n"
-"PO-Revision-Date: 2023-03-22 21:59+0200\n"
+"PO-Revision-Date: 2024-03-20 21:12+0200\n"
 "Last-Translator: ~Jhellico <jhellico@gmail.com>\n"
 "Language-Team: Python Holidays localization team\n"
 "Language: ro\n"
@@ -21,11 +21,11 @@ msgid "Anul Nou"
 msgstr ""
 
 #. Christmas Day (by old style).
-msgid "Naşterea lui Iisus Hristos (Crăciunul pe stil vechi)"
+msgid "Nașterea lui Iisus Hristos (Crăciunul pe stil vechi)"
 msgstr ""
 
 #. Christmas Day.
-msgid "Naşterea lui Iisus Hristos (Crăciunul)"
+msgid "Nașterea lui Iisus Hristos (Crăciunul)"
 msgstr ""
 
 #. International Women's Day.
@@ -33,11 +33,11 @@ msgid "Ziua internatională a femeii"
 msgstr ""
 
 #. Easter.
-msgid "Paştele"
+msgid "Paștele"
 msgstr ""
 
 #. Day of Rejoicing.
-msgid "Paştele blajinilor"
+msgid "Paștele blajinilor"
 msgstr ""
 
 #. International Workers' Solidarity Day.
@@ -47,7 +47,7 @@ msgstr ""
 #. Victory Day and Commemoration of the heroes fallen for Independence of
 #. Fatherland.
 msgid ""
-"Ziua Victoriei şi a comemorării eroilor căzuţi pentru Independenţa Patriei"
+"Ziua Victoriei și a comemorării eroilor căzuţi pentru Independenţa Patriei"
 msgstr ""
 
 #. Europe Day.
@@ -67,5 +67,5 @@ msgid "Limba noastră"
 msgstr ""
 
 #. Christmas Day (by new style).
-msgid "Naşterea lui Iisus Hristos (Crăciunul pe stil nou)"
+msgid "Nașterea lui Iisus Hristos (Crăciunul pe stil nou)"
 msgstr ""

--- a/holidays/locale/uk/LC_MESSAGES/MD.po
+++ b/holidays/locale/uk/LC_MESSAGES/MD.po
@@ -3,9 +3,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Python Holidays 0.22\n"
+"Project-Id-Version: Python Holidays 0.46\n"
 "POT-Creation-Date: 2023-03-22 21:58+0200\n"
-"PO-Revision-Date: 2023-03-22 22:00+0200\n"
+"PO-Revision-Date: 2024-03-20 21:12+0200\n"
 "Last-Translator: ~Jhellico <jhellico@gmail.com>\n"
 "Language-Team: Python Holidays localization team\n"
 "Language: uk\n"
@@ -21,11 +21,11 @@ msgid "Anul Nou"
 msgstr "Новий рік"
 
 #. Christmas Day (by old style).
-msgid "Naşterea lui Iisus Hristos (Crăciunul pe stil vechi)"
+msgid "Nașterea lui Iisus Hristos (Crăciunul pe stil vechi)"
 msgstr "Різдво Христове (за старим стилем)"
 
 #. Christmas Day.
-msgid "Naşterea lui Iisus Hristos (Crăciunul)"
+msgid "Nașterea lui Iisus Hristos (Crăciunul)"
 msgstr "Різдво Христове"
 
 #. International Women's Day.
@@ -33,11 +33,11 @@ msgid "Ziua internatională a femeii"
 msgstr "Міжнародний жіночий день"
 
 #. Easter.
-msgid "Paştele"
+msgid "Paștele"
 msgstr "Великдень"
 
 #. Day of Rejoicing.
-msgid "Paştele blajinilor"
+msgid "Paștele blajinilor"
 msgstr "Проводи"
 
 #. International Workers' Solidarity Day.
@@ -47,7 +47,7 @@ msgstr "День міжнародної солідарності трудящи�
 #. Victory Day and Commemoration of the heroes fallen for Independence of
 #. Fatherland.
 msgid ""
-"Ziua Victoriei şi a comemorării eroilor căzuţi pentru Independenţa Patriei"
+"Ziua Victoriei și a comemorării eroilor căzuţi pentru Independenţa Patriei"
 msgstr ""
 "День Перемоги та вшанування памʼяті героїв, полеглих за незалежність "
 "Батьківщини"
@@ -69,5 +69,5 @@ msgid "Limba noastră"
 msgstr "День рідної мови"
 
 #. Christmas Day (by new style).
-msgid "Naşterea lui Iisus Hristos (Crăciunul pe stil nou)"
+msgid "Nașterea lui Iisus Hristos (Crăciunul pe stil nou)"
 msgstr "Різдво Христове (за новим стилем)"

--- a/tests/countries/test_moldova.py
+++ b/tests/countries/test_moldova.py
@@ -27,9 +27,9 @@ class TestMoldova(CommonCountryTests, TestCase):
         self.assertNoHolidays(Moldova(years=1990))
 
     def test_christmas(self):
-        name_old1 = "Naşterea lui Iisus Hristos (Crăciunul)"
-        name_old2 = "Naşterea lui Iisus Hristos (Crăciunul pe stil vechi)"
-        name_new = "Naşterea lui Iisus Hristos (Crăciunul pe stil nou)"
+        name_old1 = "Nașterea lui Iisus Hristos (Crăciunul)"
+        name_old2 = "Nașterea lui Iisus Hristos (Crăciunul pe stil vechi)"
+        name_new = "Nașterea lui Iisus Hristos (Crăciunul pe stil nou)"
         self.assertHolidayName(name_old1, (f"{year}-01-07" for year in range(1991, 2014)))
         self.assertNoHolidayName(name_old1, Moldova(years=2014))
         self.assertHolidayName(name_old2, (f"{year}-01-07" for year in range(2014, 2031)))
@@ -87,22 +87,22 @@ class TestMoldova(CommonCountryTests, TestCase):
     def test_l10n_default(self):
         self.assertLocalizedHolidays(
             ("2022-01-01", "Anul Nou"),
-            ("2022-01-07", "Naşterea lui Iisus Hristos (Crăciunul pe stil vechi)"),
-            ("2022-01-08", "Naşterea lui Iisus Hristos (Crăciunul pe stil vechi)"),
+            ("2022-01-07", "Nașterea lui Iisus Hristos (Crăciunul pe stil vechi)"),
+            ("2022-01-08", "Nașterea lui Iisus Hristos (Crăciunul pe stil vechi)"),
             ("2022-03-08", "Ziua internatională a femeii"),
-            ("2022-04-24", "Paştele"),
-            ("2022-04-25", "Paştele"),
+            ("2022-04-24", "Paștele"),
+            ("2022-04-25", "Paștele"),
             ("2022-05-01", "Ziua internaţională a solidarităţii oamenilor muncii"),
-            ("2022-05-02", "Paştele blajinilor"),
+            ("2022-05-02", "Paștele blajinilor"),
             (
                 "2022-05-09",
-                "Ziua Europei; Ziua Victoriei şi a comemorării eroilor "
+                "Ziua Europei; Ziua Victoriei și a comemorării eroilor "
                 "căzuţi pentru Independenţa Patriei",
             ),
             ("2022-06-01", "Ziua Ocrotirii Copilului"),
             ("2022-08-27", "Ziua independenţei Republicii Moldova"),
             ("2022-08-31", "Limba noastră"),
-            ("2022-12-25", "Naşterea lui Iisus Hristos (Crăciunul pe stil nou)"),
+            ("2022-12-25", "Nașterea lui Iisus Hristos (Crăciunul pe stil nou)"),
         )
 
     def test_l10n_en_us(self):


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Romanian alphabet use U+0219 (`ș`), not U+015F (`ş`). 

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
