### PR TITLE
 Update CI/CD: fix macOS Python versions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,8 +21,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5
         with:
+          check-latest: true
           python-version: '3.12'
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
@@ -46,18 +47,33 @@ jobs:
           - '3.12'
           - 'pypy-3.9'
           - 'pypy-3.10'
+        exclude:
+          - os: 'macos-latest'
+            python-version: '3.8'
+          - os: 'macos-latest'
+            python-version: '3.9'
+          - os: 'macos-latest'
+            python-version: 'pypy-3.9'
+        include:
+          - os: 'macos-13'
+            python-version: '3.8'
+          - os: 'macos-13'
+            python-version: '3.9'
+          - os: 'macos-13'
+            python-version: 'pypy-3.9'
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5
         with:
+          allow-prereleases: true
           cache: pip
           cache-dependency-path: |
             requirements/runtime.txt
             requirements/tests.txt
+          check-latest: true
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
 
       - name: Install dependencies
         run: |
@@ -84,10 +100,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5
         with:
           cache: pip
           cache-dependency-path: requirements/runtime.txt
+          check-latest: true
           python-version: '3.12'
 
       - name: Install dependencies
@@ -131,12 +148,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5
         with:
           cache: pip
           cache-dependency-path: |
             requirements/runtime.txt
             requirements/tests.txt
+          check-latest: true
           python-version: '3.12'
 
       - name: Get package artifacts


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Resolves #1777 

This PR addresses the CI/CD issue related to Python versions for the latest macOS image.
Other changes:
  - change `actions/setup-python@v5.1.0` to `actions/setup-python@v5`
  - add `check-latest: true` for `setup-python` action


## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
