### PR TITLE
python3.6 support v0.48

### DIFF
--- a/holidays/countries/azerbaijan.py
+++ b/holidays/countries/azerbaijan.py
@@ -149,7 +149,8 @@ class Azerbaijan(ObservedHolidayBase, InternationalHolidays, IslamicHolidays, St
             # 6. If the holidays of Qurban and Ramadan coincide with another holiday
             # that is not considered a working day, the next working day is considered a rest day.
             for dt_observed in sorted(dts_bairami.difference(dts_non_observed)):
-                if len(dt_holidays := self.get_list(dt_observed)) == 1:
+                dt_holidays = self.get_list(dt_observed)
+                if len(dt_holidays) == 1:
                     continue
                 for name in dt_holidays:
                     if name in bayrami_names:

--- a/holidays/countries/botswana.py
+++ b/holidays/countries/botswana.py
@@ -61,7 +61,8 @@ class Botswana(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, St
         self._add_observed(self._add_holiday_oct_1("Botswana Day Holiday"))
 
         self._add_observed(self._add_christmas_day("Christmas Day"), rule=SUN_TO_NEXT_TUE)
-        self._add_observed(dec_26 := self._add_christmas_day_two("Boxing Day"))
+        dec_26 = self._add_christmas_day_two("Boxing Day")
+        self._add_observed(dec_26)
 
         if self.observed and self._year >= 2016 and self._is_saturday(dec_26):
             self._add_holiday_dec_28("Boxing Day Holiday")

--- a/holidays/countries/eswatini.py
+++ b/holidays/countries/eswatini.py
@@ -48,14 +48,16 @@ class Eswatini(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, St
         self._add_ascension_thursday("Ascension Day")
 
         if self._year >= 1987:
+            apr_19 = self._add_holiday_apr_19("King's Birthday")
             self._add_observed(
-                apr_19 := self._add_holiday_apr_19("King's Birthday"),
+                apr_19,
                 rule=SUN_TO_NEXT_TUE if apr_19 == self._easter_sunday else SUN_TO_NEXT_MON,
             )
 
         if self._year >= 1969:
+            apr_25 = self._add_holiday_apr_25("National Flag Day")
             self._add_observed(
-                apr_25 := self._add_holiday_apr_25("National Flag Day"),
+                apr_25,
                 rule=SUN_TO_NEXT_TUE if apr_25 == self._easter_sunday else SUN_TO_NEXT_MON,
             )
 

--- a/holidays/countries/serbia.py
+++ b/holidays/countries/serbia.py
@@ -55,8 +55,9 @@ class Serbia(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
         name = tr("Празник рада")
         self._add_observed(self._add_labor_day(name), rule=SUN_TO_NEXT_TUE)
 
+        may_2 = self._add_labor_day_two(name)
         self._add_observed(
-            may_2 := self._add_labor_day_two(name),
+            may_2,
             rule=SUN_TO_NEXT_TUE if may_2 == self._easter_sunday else SUN_TO_NEXT_MON,
         )
 

--- a/holidays/countries/zimbabwe.py
+++ b/holidays/countries/zimbabwe.py
@@ -50,10 +50,10 @@ class Zimbabwe(ObservedHolidayBase, ChristianHolidays, InternationalHolidays):
 
         # Easter Monday.
         self._add_easter_monday("Easter Monday")
-
+        apr_18 = self._add_holiday_apr_18("Independence Day")
         self._add_observed(
             # Independence Day.
-            apr_18 := self._add_holiday_apr_18("Independence Day"),
+            apr_18,
             rule=SUN_TO_NEXT_TUE if apr_18 == self._easter_sunday else SUN_TO_NEXT_MON,
         )
 

--- a/holidays/groups/custom.py
+++ b/holidays/groups/custom.py
@@ -21,15 +21,16 @@ class StaticHolidays:
     def __init__(self, cls) -> None:
         for attribute_name in cls.__dict__.keys():
             # Special holidays.
+            value = getattr(cls, attribute_name, None)
             if attribute_name.startswith("special_") and (
-                value := getattr(cls, attribute_name, None)
+                value
             ):
                 setattr(self, attribute_name, value)
                 self.has_special_holidays = True
 
             # Substituted holidays.
             elif attribute_name.startswith("substituted_") and (
-                value := getattr(cls, attribute_name, None)
+                value
             ):
                 setattr(self, attribute_name, value)
                 self.has_substituted_holidays = True

--- a/holidays/tests.py
+++ b/holidays/tests.py
@@ -1,0 +1,101 @@
+""" Generic unit tests for the module. """
+import unittest
+import holidays
+
+class TestModuleGeneric(unittest.TestCase):
+    """ Generic tests of the module for python 3.6 """
+    def test_nyse(self):
+        """Test saving security items and loading them from the repository"""
+
+        test_cases = {
+            "success": {
+                "year": 2021,
+                "expectedErr": None,
+            }
+        }
+        
+        for key, case in test_cases.items():
+            with self.subTest(key=key):
+                if case["expectedErr"]:
+                    with self.assertRaises(case["expectedErr"]):
+                        holidays.NYSE(years=case.get("year"))
+                        
+                else:
+                    holidays.NYSE(years=case.get("year"))
+                    
+    def test_us(self):
+        """Test saving security items and loading them from the repository"""
+
+        test_cases = {
+            "success": {
+                "year": 2021,
+                "expectedErr": None,
+            }
+        }
+        
+        for key, case in test_cases.items():
+            with self.subTest(key=key):
+                if case["expectedErr"]:
+                    with self.assertRaises(case["expectedErr"]):
+                        holidays.US(years=case.get("year"))
+                        
+                else:
+                    holidays.US(years=case.get("year"))
+                    
+    def test_india(self):
+        """Test saving security items and loading them from the repository"""
+
+        test_cases = {
+            "success": {
+                "year": 2021,
+                "expectedErr": None,
+            }
+        }
+        
+        for key, case in test_cases.items():
+            with self.subTest(key=key):
+                if case["expectedErr"]:
+                    with self.assertRaises(case["expectedErr"]):
+                        holidays.India(years=case.get("year"))
+                        
+                else:
+                    holidays.India(years=case.get("year"))
+                    
+    def test_bolivia(self):
+        """Test saving security items and loading them from the repository"""
+
+        test_cases = {
+            "success": {
+                "year": 2021,
+                "expectedErr": None,
+            }
+        }
+        
+        for key, case in test_cases.items():
+            with self.subTest(key=key):
+                if case["expectedErr"]:
+                    with self.assertRaises(case["expectedErr"]):
+                        holidays.Bolidvia(years=case.get("year"))
+                        
+                else:
+                    holidays.Bolivia(years=case.get("year"))
+                    
+        
+    def test_Tunisia(self):
+        """Test saving security items and loading them from the repository"""
+
+        test_cases = {
+            "success": {
+                "year": 2021,
+                "expectedErr": None,
+            }
+        }
+        
+        for key, case in test_cases.items():
+            with self.subTest(key=key):
+                if case["expectedErr"]:
+                    with self.assertRaises(case["expectedErr"]):
+                        holidays.Tunisia(years=case.get("year"))
+                        
+                else:
+                    holidays.Tunisia(years=case.get("year"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "holidays"
 description = "Generate and work with holidays in Python"
 license = { file = "LICENSE" }
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.6"
 dynamic = ["version"]
 
 authors = [{ email = "dr.prodigy.github@gmail.com", name = "Maurizio Montel" }]


### PR DESCRIPTION
## Intent
Revert the forked package to python version 3.6

----
## Type
Enhancement

----
## Usage
This module will be used in servers that do not run a python version more recent than 3.6 and require the use of the python holidays module.
----
## Implementations Details
Adapt code base to Python 3.6.
details are apparent in the PR's commit.

----
## Unit tests
2836 OK
1 Failure (metadata file missing ?)
![image](https://github.com/vacanza/python-holidays/assets/123632995/640159a9-b800-46c5-8db9-3770c833271c)
