### PR TITLE
Synchronize entity dynamic imports

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,6 +52,7 @@ Heikki Orsila
 Henrik Sozzi
 Hugh McNamara
 Hugo van Kemenade
+Isabelle COWAN-BERGMAN
 Jacky Han
 Jacob Punter
 Jaemin Kim

--- a/holidays/registry.py
+++ b/holidays/registry.py
@@ -179,6 +179,9 @@ FINANCIAL: RegistryDict = {
     "ny_stock_exchange": ("NewYorkStockExchange", "NYSE", "XNYS"),
 }
 
+# A re-entrant lock. Once a thread has acquired a re-entrant lock,
+# the same thread may acquire it again without blocking.
+# https://docs.python.org/3/library/threading.html#rlock-objects
 IMPORT_LOCK = RLock()
 
 


### PR DESCRIPTION
## Proposed change

Perform dynamic imports in registry in dedicated worker thread to avoid deadlocks from concurrent calls to `importlib.import_module` for the same module from different threads.  This may not be sufficient if other code outside of python-holdays is importing these moduels directly.  I believe this cpython issue is related https://bugs.python.org/issue38884.  This should resolve (through a different implementation) #1514.

Here is a flamegraph of the deadlock in action on one thread:
![image](https://github.com/vacanza/python-holidays/assets/7987724/2eadd8a0-146a-4763-8c57-af0193e0ed22)

My main concern with this PR is that it may introduce a slight performance degradation.  I'm not sure adding a test will be feasible, as the deadlock is inherently racy.  Making a reliable production in the python-holidays code would require adding a lot of synchronization points within python-holidays to instrument such a test and hammering the `importlib.import_module` with many threads and than calling `importlib.invalidate_caches` in a loop until the issue is reproduced.

## Type of change

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source