### PR TITLE
Update observed rules: add holiday removal support

### DIFF
--- a/holidays/countries/angola.py
+++ b/holidays/countries/angola.py
@@ -12,7 +12,7 @@
 
 from datetime import date
 from gettext import gettext as tr
-from typing import Tuple
+from typing import Optional, Tuple
 
 from holidays.calendars.gregorian import AUG, SEP
 from holidays.groups import ChristianHolidays, InternationalHolidays, StaticHolidays
@@ -59,7 +59,7 @@ class Angola(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         # it rolls over to the following Monday.
         return dt >= date(1996, SEP, 27)
 
-    def _add_observed(self, dt: date, **kwargs) -> Tuple[bool, date]:
+    def _add_observed(self, dt: date, **kwargs) -> Tuple[bool, Optional[date]]:
         # As per Law # #11/18, from 2018/9/10, when public holiday falls on Tuesday or Thursday,
         # the Monday or Friday is also a holiday.
         kwargs.setdefault(

--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -12,6 +12,7 @@
 
 from datetime import date
 from gettext import gettext as tr
+from typing import Optional
 
 from holidays.calendars.gregorian import MAR, APR, JUN, JUL, SEP
 from holidays.constants import GOVERNMENT, OPTIONAL, PUBLIC
@@ -69,7 +70,7 @@ class Canada(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _get_nearest_monday(self, *args) -> date:
+    def _get_nearest_monday(self, *args) -> Optional[date]:
         return self._get_observed_date(date(self._year, *args), rule=ALL_TO_NEAREST_MON)
 
     def _add_statutory_holidays(self):

--- a/holidays/countries/jersey.py
+++ b/holidays/countries/jersey.py
@@ -11,7 +11,7 @@
 #  License: MIT (see LICENSE file)
 
 from datetime import date
-from typing import Tuple
+from typing import Optional, Tuple
 
 from holidays.calendars.gregorian import JAN, APR, MAY, JUN, JUL, SEP, OCT, DEC
 from holidays.groups import ChristianHolidays, InternationalHolidays, StaticHolidays
@@ -54,7 +54,7 @@ class Jersey(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, Stat
         kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_WORKDAY)
         ObservedHolidayBase.__init__(self, *args, **kwargs)
 
-    def _add_observed(self, dt: date, **kwargs) -> Tuple[bool, date]:
+    def _add_observed(self, dt: date, **kwargs) -> Tuple[bool, Optional[date]]:
         # Prior to 2004, in-lieu are only given for Sundays.
         # https://www.jerseylaw.je/laws/enacted/Pages/RO-123-2004.aspx
         kwargs.setdefault(

--- a/holidays/countries/new_zealand.py
+++ b/holidays/countries/new_zealand.py
@@ -11,6 +11,7 @@
 #  License: MIT (see LICENSE file)
 
 from datetime import date
+from typing import Optional
 
 from holidays.calendars.gregorian import JAN, FEB, MAR, JUN, JUL, SEP, NOV, DEC, _timedelta
 from holidays.groups import ChristianHolidays, InternationalHolidays, StaticHolidays
@@ -74,7 +75,7 @@ class NewZealand(ObservedHolidayBase, ChristianHolidays, InternationalHolidays, 
         kwargs.setdefault("observed_rule", SAT_SUN_TO_NEXT_MON)
         super().__init__(*args, **kwargs)
 
-    def _get_nearest_monday(self, *args) -> date:
+    def _get_nearest_monday(self, *args) -> Optional[date]:
         dt = args if len(args) > 1 else args[0]
         dt = dt if isinstance(dt, date) else date(self._year, *dt)
         return self._get_observed_date(dt, rule=ALL_TO_NEAREST_MON)

--- a/holidays/observed_holiday_base.py
+++ b/holidays/observed_holiday_base.py
@@ -17,7 +17,7 @@ from holidays.calendars.gregorian import MON, TUE, WED, THU, FRI, SAT, SUN, _tim
 from holidays.holiday_base import DateArg, HolidayBase
 
 
-class ObservedRule(Dict[int, int]):
+class ObservedRule(Dict[int, Optional[int]]):
     __slots__ = ()
 
     def __add__(self, other):
@@ -113,18 +113,23 @@ class ObservedHolidayBase(HolidayBase):
                 return dt_work
         return dt
 
-    def _get_observed_date(self, dt: date, rule: ObservedRule) -> date:
+    def _get_observed_date(self, dt: date, rule: ObservedRule) -> Optional[date]:
         delta = rule.get(dt.weekday(), 0)
-        if delta != 0:
-            if abs(delta) == 7:
-                dt = self._get_next_workday(dt, delta // 7)
-            else:
-                dt = _timedelta(dt, delta)
+        if delta:
+            return (
+                self._get_next_workday(dt, delta // 7)
+                if abs(delta) == 7
+                else _timedelta(dt, delta)
+            )
+        # Goes after `if delta` case as a less probable.
+        elif delta is None:
+            return None
+
         return dt
 
     def _add_observed(
         self, dt: DateArg, name: Optional[str] = None, rule: Optional[ObservedRule] = None
-    ) -> Tuple[bool, date]:
+    ) -> Tuple[bool, Optional[date]]:
         dt = dt if isinstance(dt, date) else date(self._year, *dt)
 
         if not self.observed or not self._is_observed(dt):
@@ -133,6 +138,11 @@ class ObservedHolidayBase(HolidayBase):
         dt_observed = self._get_observed_date(dt, rule or self._observed_rule)
         if dt_observed == dt:
             return False, dt
+
+        # SAT_TO_NONE and similar cases.
+        if dt_observed is None:
+            self.pop(dt)
+            return False, None
 
         estimated_label = self.tr(getattr(self, "estimated_label", ""))
         observed_label = self.tr(
@@ -158,7 +168,9 @@ class ObservedHolidayBase(HolidayBase):
 
         return True, dt_observed
 
-    def _move_holiday(self, dt: date, rule: Optional[ObservedRule] = None) -> Tuple[bool, date]:
+    def _move_holiday(
+        self, dt: date, rule: Optional[ObservedRule] = None
+    ) -> Tuple[bool, Optional[date]]:
         is_observed, dt_observed = self._add_observed(dt, rule=rule)
         if is_observed:
             self.pop(dt)

--- a/tests/test_observed_holiday_base.py
+++ b/tests/test_observed_holiday_base.py
@@ -1,0 +1,56 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see AUTHORS file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/python-holidays
+#  License: MIT (see LICENSE file)
+
+from datetime import date
+from unittest import TestCase
+
+from holidays.calendars.gregorian import MON, SUN
+from holidays.observed_holiday_base import ObservedHolidayBase, ObservedRule
+
+
+class TestObservedHolidayBase(TestCase):
+    SUNDAY = date(2024, 5, 12)
+    MONDAY = date(2024, 5, 13)
+    SUN_TO_NONE = ObservedRule({SUN: None})
+    MON_TO_TUE = ObservedRule({MON: +1})
+
+    def setUp(self):
+        self.ohb = ObservedHolidayBase(observed_rule=ObservedRule({MON: None}))
+        self.ohb.observed_label = "%s (Observed Label)"
+        self.ohb._populate(2024)
+
+    def test_get_observed_date(self):
+        self.assertIsNone(self.ohb._get_observed_date(self.SUNDAY, rule=self.SUN_TO_NONE))
+
+    def test_observed_rules(self):
+        self.assertEqual(
+            (False, None),
+            self.ohb._add_observed(
+                self.ohb._add_holiday("Test Holiday", self.SUNDAY), rule=self.SUN_TO_NONE
+            ),
+        )
+
+        self.assertEqual(
+            (True, date(2024, 5, 14)),
+            self.ohb._add_observed(
+                self.ohb._add_holiday("Test Holiday", self.MONDAY), rule=self.MON_TO_TUE
+            ),
+        )
+
+        self.assertEqual(
+            dict(self.ohb),
+            {
+                date(2024, 5, 13): "Test Holiday",
+                date(2024, 5, 14): "Test Holiday (Observed Label)",
+            },
+            self.ohb,
+        )


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

This PR extends our `ObservedRule` class to support "move to None" cases. In other words it's a holiday removal (no holiday + no observance type of rule). I've got this idea while reviewing https://github.com/vacanza/python-holidays/pull/1792, specifically from [this comment](https://github.com/vacanza/python-holidays/pull/1792/files#r1602976377). It'll be useful for making `IFEU` holiday calendar a bit cleaner.

Let me know your thoughts on this when you get a chance.

P.S. I did my best to avoid naming the rule `???_TO_NONDAY` :)


## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
