### PR TITLE
Add v1 future incompatibility warning

### DIFF
--- a/holidays/__init__.py
+++ b/holidays/__init__.py
@@ -12,7 +12,13 @@
 
 # flake8: noqa: F403
 
+import warnings
+
 from holidays.constants import *
+from holidays.deprecation import (
+    FUTURE_INCOMPATIBILITY_WARNING_TEMPLATE,
+    FutureIncompatibilityWarning,
+)
 from holidays.holiday_base import *
 from holidays.registry import EntityLoader
 from holidays.utils import *
@@ -22,3 +28,8 @@ __version__ = "0.50"
 
 EntityLoader.load("countries", globals())
 EntityLoader.load("financial", globals())
+
+warnings.warn(
+    FUTURE_INCOMPATIBILITY_WARNING_TEMPLATE.format(version=__version__),
+    FutureIncompatibilityWarning,
+)

--- a/holidays/deprecation.py
+++ b/holidays/deprecation.py
@@ -1,0 +1,33 @@
+#  holidays
+#  --------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: Vacanza Team and individual contributors (see AUTHORS file)
+#           dr-prodigy <dr.prodigy.github@gmail.com> (c) 2017-2023
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/vacanza/python-holidays
+#  License: MIT (see LICENSE file)
+
+FUTURE_INCOMPATIBILITY_WARNING_TEMPLATE = """
+
+This is a future version incompatibility warning from Python Holidays library v{version}
+to inform you about an upcoming change in our API versioning strategy that may affect your
+project's dependencies. Starting from version 1.0 onwards, we will be following a loose form of
+Semantic Versioning (SemVer) to provide clearer communication regarding any potential breaking
+changes.
+
+This means that while we strive to maintain backward compatibility, there might be occasional
+updates that introduce breaking changes to our API. To ensure the stability of your projects,
+we highly recommend pinning the version of our API that you rely on. You can pin your current
+holidays v0.x dependency (e.g., holidays=={version}) or limit it (e.g., holidays<1.0) in order to
+avoid potentially unwanted upgrade to the version 1.0 when it's released (ETA 2024Q4 - 2025Q1).
+
+If you have any questions or concerns regarding this change, please don't hesitate to reach out
+to us via https://github.com/vacanza/python-holidays/discussions/1800.
+"""
+
+
+class FutureIncompatibilityWarning(DeprecationWarning):
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ disable_error_code = ["override"]
 module = "holidays.groups.*"
 disable_error_code = "attr-defined"
 
+[tool.pytest.ini_options]
+addopts = "-p no:warnings"
+
 [tool.rstcheck]
 ignore_directives = ["automodule", "autosummary"]
 ignore_languages = ["python"]

--- a/tests/countries/test_eswatini.py
+++ b/tests/countries/test_eswatini.py
@@ -110,7 +110,3 @@ class TestEswatini(CommonCountryTests, TestCase):
         warnings.simplefilter("default")
         with self.assertWarns(Warning):
             holidays.Swaziland()
-
-        warnings.simplefilter("error")
-        with self.assertRaises(Warning):
-            holidays.Swaziland()

--- a/tests/countries/test_south_korea.py
+++ b/tests/countries/test_south_korea.py
@@ -541,10 +541,6 @@ class TestSouthKorea(CommonCountryTests, TestCase):
         with self.assertWarns(Warning):
             Korea()
 
-        warnings.simplefilter("error")
-        with self.assertRaises(Warning):
-            Korea()
-
     def test_2020_all(self):
         self.assertHolidays(
             SouthKorea(categories=(BANK, PUBLIC), years=2020),

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,3 @@ deps =
 commands =
     pre-commit autoupdate
     pre-commit run --all-files
-
-[pytest]
-filterwarnings =
-    ignore:The --rsyncdir .* are deprecated:DeprecationWarning


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

This PR adds v1 future incompatibility warning appearing upon `holidays` import. It includes a link to discussion thread to gather ideas and opinions on how to make it as smooth as possible.

## Type of change 

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
