### PR TITLE
Fix docs: update Italy docstring

### DIFF
--- a/holidays/countries/italy.py
+++ b/holidays/countries/italy.py
@@ -19,7 +19,7 @@ class Italy(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHoliday
     """
     References:
         - https://en.wikipedia.org/wiki/Public_holidays_in_Italy
-        - `Provinces holidays <https://it.wikipedia.org/wiki/Santi_patroni_cattolici_delle_citt%C3%A0_capoluogo_di_provincia_italiane>`_# noqa: E501
+        - `Provinces holidays <https://it.wikipedia.org/wiki/Santi_patroni_cattolici_delle_citt%C3%A0_capoluogo_di_provincia_italiane>`_  # noqa: E501
     """
 
     country = "IT"


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Fix `sphinx.errors.SphinxWarning: /Users/ark/Dev/python-holidays/holidays/countries/italy.py:docstring of holidays.countries.italy.Italy:3:Inline interpreted text or phrase reference start-string without end-string.` error that I was getting locally.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
