### PR TITLE
Update CI/CD job concurrency

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,8 +9,8 @@ env:
   FORCE_COLOR: 1
 
 concurrency:
-  cancel-in-progress: true
-  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: ${{ !contains(fromJSON('["dev", "main"]'), github.ref_name) && !startsWith(github.ref_name, 'v') }}
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   pre-commit:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,8 +9,8 @@ env:
   FORCE_COLOR: 1
 
 concurrency:
-  cancel-in-progress: ${{ !contains(fromJSON('["dev", "main"]'), github.ref_name) && !startsWith(github.ref_name, 'v') }}
-  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.head_ref || github.ref }}
 
 jobs:
   pre-commit:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macOS-latest
+          - macos-latest
           - ubuntu-latest
           - windows-latest
         python-version:
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macOS-latest
+          - macos-latest
           - ubuntu-latest
           - windows-latest
     steps:


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

This is another attempt (see the [previous PR](https://github.com/vacanza/python-holidays/pull/1823)) to reduce our CI/CD resources consumption by not running the jobs twice for PR/commit pushes.


## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
