### PR TITLE
Extend `HolidayBase::__setitem__` to handle names including `; `

### DIFF
--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -664,8 +664,7 @@ class HolidayBase(Dict[date, str]):
             # If there are multiple holidays on the same date
             # order their names alphabetically.
             holiday_names = set(self[key].split(HOLIDAY_NAME_DELIMITER))
-            for holiday_name in value.split(HOLIDAY_NAME_DELIMITER):
-                holiday_names.add(holiday_name)
+            holiday_names.update(value.split(HOLIDAY_NAME_DELIMITER))
             value = HOLIDAY_NAME_DELIMITER.join(sorted(holiday_names))
 
         dict.__setitem__(self, self.__keytransform__(key), value)

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -664,8 +664,8 @@ class HolidayBase(Dict[date, str]):
             # If there are multiple holidays on the same date
             # order their names alphabetically.
             holiday_names = set(self[key].split(HOLIDAY_NAME_DELIMITER))
-            for name in value.split(HOLIDAY_NAME_DELIMITER):
-                holiday_names.add(name)
+            for holiday_name in value.split(HOLIDAY_NAME_DELIMITER):
+                holiday_names.add(holiday_name)
             value = HOLIDAY_NAME_DELIMITER.join(sorted(holiday_names))
 
         dict.__setitem__(self, self.__keytransform__(key), value)

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -664,7 +664,8 @@ class HolidayBase(Dict[date, str]):
             # If there are multiple holidays on the same date
             # order their names alphabetically.
             holiday_names = set(self[key].split(HOLIDAY_NAME_DELIMITER))
-            holiday_names.add(value)
+            for name in value.split(HOLIDAY_NAME_DELIMITER):
+                holiday_names.add(name)
             value = HOLIDAY_NAME_DELIMITER.join(sorted(holiday_names))
 
         dict.__setitem__(self, self.__keytransform__(key), value)

--- a/tests/test_holiday_base.py
+++ b/tests/test_holiday_base.py
@@ -1013,6 +1013,10 @@ class TestStandardMethods(unittest.TestCase):
         self.assertIn("2014-01-03", self.hb)
         self.assertEqual(self.hb["2014-01-03"], "Custom Holiday")
 
+        self.hb["2014-01-04"] = "Custom Holiday"
+        self.hb["2014-01-04"] = "Custom Holiday; Another Custom Holiday"
+        self.assertEqual(self.hb["2014-01-04"], "Another Custom Holiday; Custom Holiday")
+
     def test_update(self):
         self.hb.update(
             {


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Handle `; ` in holidays names.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/upgrade)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
