### PR TITLE
Update SG: add 2025 official holidays

### DIFF
--- a/holidays/countries/singapore.py
+++ b/holidays/countries/singapore.py
@@ -269,7 +269,7 @@ class SingaporeIslamicHolidays(_CustomIslamicHolidays):
         2022: (JUL, 10),
         2023: (JUN, 29),
         2024: (JUN, 17),
-        2025:(JUN, 7,),
+        2025: (JUN, 7,),
     }
 
     # Hari Raya Puasa
@@ -298,7 +298,7 @@ class SingaporeIslamicHolidays(_CustomIslamicHolidays):
         2022: (MAY, 3),
         2023: (APR, 22),
         2024: (APR, 10),
-        2025:(MAR, 31),
+        2025: (MAR, 31),
     }
 
 

--- a/holidays/countries/singapore.py
+++ b/holidays/countries/singapore.py
@@ -177,6 +177,7 @@ class SingaporeBuddhistHolidays(_CustomBuddhistHolidays):
         2022: (MAY, 15),
         2023: (JUN, 2),
         2024: (MAY, 22),
+        2025: (MAY, 12),
     }
 
 
@@ -206,10 +207,12 @@ class SingaporeChineseHolidays(_CustomChineseHolidays):
         2022: (FEB, 1),
         2023: (JAN, 22),
         2024: (FEB, 10),
+        2025: (JAN, 29),
     }
 
 
 class SingaporeHinduHolidays(_CustomHinduHolidays):
+    # Deepavali
     DIWALI_DATES = {
         2001: (NOV, 14),
         2002: (NOV, 3),
@@ -235,10 +238,12 @@ class SingaporeHinduHolidays(_CustomHinduHolidays):
         2022: (OCT, 24),
         2023: (NOV, 12),
         2024: (OCT, 31),
+        2025: (OCT, 20),
     }
 
 
 class SingaporeIslamicHolidays(_CustomIslamicHolidays):
+    # Hari Raya Haji
     EID_AL_ADHA_DATES = {
         2001: (MAR, 6),
         2002: (FEB, 23),
@@ -264,8 +269,10 @@ class SingaporeIslamicHolidays(_CustomIslamicHolidays):
         2022: (JUL, 10),
         2023: (JUN, 29),
         2024: (JUN, 17),
+        2025:(JUN, 7,),
     }
 
+    # Hari Raya Puasa
     EID_AL_FITR_DATES = {
         2001: (DEC, 16),
         2002: (DEC, 6),
@@ -291,6 +298,7 @@ class SingaporeIslamicHolidays(_CustomIslamicHolidays):
         2022: (MAY, 3),
         2023: (APR, 22),
         2024: (APR, 10),
+        2025:(MAR, 31),
     }
 
 

--- a/holidays/countries/singapore.py
+++ b/holidays/countries/singapore.py
@@ -269,7 +269,7 @@ class SingaporeIslamicHolidays(_CustomIslamicHolidays):
         2022: (JUL, 10),
         2023: (JUN, 29),
         2024: (JUN, 17),
-        2025: (JUN, 7,),
+        2025: (JUN, 7),
     }
 
     # Hari Raya Puasa

--- a/tests/countries/test_singapore.py
+++ b/tests/countries/test_singapore.py
@@ -178,6 +178,21 @@ class TestSingapore(CommonCountryTests, TestCase):
             ("2024-12-25", "Christmas Day"),
         )
 
+    def test_2025(self):
+        self.assertHolidays(
+            ("2025-01-01", "New Year's Day"),
+            ("2025-01-29", "Chinese New Year"),
+            ("2025-01-30", "Chinese New Year"),
+            ("2025-03-31", "Hari Raya Puasa"),
+            ("2025-04-18", "Good Friday"),
+            ("2025-05-01", "Labour Day"),
+            ("2025-05-12", "Vesak Day"),
+            ("2025-06-07", "Hari Raya Haji"),
+            ("2025-08-09", "National Day"),
+            ("2025-10-20", "Deepavali"),
+            ("2025-12-25", "Christmas Day"),
+        )
+
     def test_non_observed(self):
         self.assertNoNonObservedHoliday("2023-01-02")
 


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Added 2025 official holidays for Singapore

Source: Official Government news release at https://www.mom.gov.sg/newsroom/press-releases/2024/0805-public-holidays-for-2025

Testing source: official dates at https://www.mom.gov.sg/employment-practices/public-holidays

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [X] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [X] I've followed the [contributing guidelines][contributing-guidelines]
- [] I've run `make pre-commit`, it didn't generate any changes
  **Not working, but Git runs it automatically**
  ```
  make pre-commit
  make: The term 'make' is not recognized as a name of a cmdlet, function, script file, or executable program.
  Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
  ```
- [] I've run `make test`, all tests passed locally
 **Not working, but ran it manually from IDE**
  ```
  make test
  make: The term 'make' is not recognized as a name of a cmdlet, function, script file, or executable program.
  Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
  ```

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
