### PR TITLE
Update utils.py

### DIFF
--- a/holidays/utils.py
+++ b/holidays/utils.py
@@ -22,9 +22,9 @@ __all__ = (
 
 import warnings
 from functools import lru_cache
-from typing import Dict, Iterable, List, Optional, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Union
 
-from holidays.holiday_base import HolidayBase
+from holidays.holiday_base import CategoryArg, HolidayBase
 from holidays.registry import EntityLoader
 
 

--- a/holidays/utils.py
+++ b/holidays/utils.py
@@ -37,7 +37,7 @@ def country_holidays(
     prov: Optional[str] = None,
     state: Optional[str] = None,
     language: Optional[str] = None,
-    categories: Optional[Tuple[str]] = None,
+    categories: Optional[Tuple[str, ...]] = None,
 ) -> HolidayBase:
     """
     Returns a new dictionary-like :py:class:`HolidayBase` object for the public

--- a/holidays/utils.py
+++ b/holidays/utils.py
@@ -37,7 +37,7 @@ def country_holidays(
     prov: Optional[str] = None,
     state: Optional[str] = None,
     language: Optional[str] = None,
-    categories: Optional[Tuple[str, ...]] = None,
+    categories: Optional[CategoryArg] = None,
 ) -> HolidayBase:
     """
     Returns a new dictionary-like :py:class:`HolidayBase` object for the public


### PR DESCRIPTION
## Proposed change

Changed the type annotation of the categories argument in the utils.country_holidays() method from Optional[Tuple[str]] to Optional[Tuple[str, ...]] to allow a tuple with multiple strings just like the type of HolidayBase.supported_categories

## Type of change

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

- [ ] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I've run `make pre-commit`, it didn't generate any changes
- [ ] I've run `make test`, all tests passed locally

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
