### PR TITLE
Add special weekends format for certain countries

### DIFF
--- a/holidays/countries/algeria.py
+++ b/holidays/countries/algeria.py
@@ -12,6 +12,7 @@
 
 from gettext import gettext as tr
 
+from holidays.calendars.gregorian import THU, FRI, SAT, SUN
 from holidays.groups import InternationalHolidays, IslamicHolidays
 from holidays.holiday_base import HolidayBase
 
@@ -38,6 +39,16 @@ class Algeria(HolidayBase, InternationalHolidays, IslamicHolidays):
         super().__init__(*args, **kwargs)
 
     def _populate_public_holidays(self):
+        # The resting days are Friday and Saturday since 2009.
+        # Previously, these were on Thursday and Friday as implemented in 1976.
+        # https://www.thenationalnews.com/mena/2021/12/07/when-is-the-weekend-in-the-arab-world/
+        if self._year >= 2009:
+            self.weekend = {FRI, SAT}
+        elif self._year >= 1976:
+            self.weekend = {THU, SAT}
+        else:
+            self.weekend = {SAT, SUN}
+
         # New Year's Day.
         self._add_new_years_day(tr("رأس السنة الميلادية"))
 

--- a/holidays/countries/bangladesh.py
+++ b/holidays/countries/bangladesh.py
@@ -10,6 +10,7 @@
 #  Website: https://github.com/vacanza/python-holidays
 #  License: MIT (see LICENSE file)
 
+from holidays.calendars.gregorian import FRI, SAT
 from holidays.groups import InternationalHolidays
 from holidays.holiday_base import HolidayBase
 
@@ -22,6 +23,7 @@ class Bangladesh(HolidayBase, InternationalHolidays):
     """
 
     country = "BD"
+    weekend = {FRI, SAT}
 
     def __init__(self, *args, **kwargs):
         InternationalHolidays.__init__(self)

--- a/holidays/countries/brunei.py
+++ b/holidays/countries/brunei.py
@@ -13,7 +13,22 @@
 from gettext import gettext as tr
 
 from holidays.calendars import _CustomIslamicHolidays
-from holidays.calendars.gregorian import JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP, OCT, NOV, DEC
+from holidays.calendars.gregorian import (
+    JAN,
+    FEB,
+    MAR,
+    APR,
+    MAY,
+    JUN,
+    JUL,
+    AUG,
+    SEP,
+    OCT,
+    NOV,
+    DEC,
+    FRI,
+    SUN,
+)
 from holidays.groups import (
     ChineseCalendarHolidays,
     ChristianHolidays,
@@ -75,6 +90,7 @@ class Brunei(
     # %s (observed, estimated).
     observed_estimated_label = tr("%s (diperhatikan, anggaran)")
     supported_languages = ("en_US", "ms", "th")
+    weekend = {FRI, SUN}
 
     def __init__(self, *args, **kwargs):
         ChineseCalendarHolidays.__init__(self)

--- a/holidays/countries/egypt.py
+++ b/holidays/countries/egypt.py
@@ -12,6 +12,7 @@
 
 from gettext import gettext as tr
 
+from holidays.calendars.gregorian import FRI, SAT
 from holidays.calendars.julian import JULIAN_CALENDAR
 from holidays.groups import ChristianHolidays, IslamicHolidays, InternationalHolidays
 from holidays.holiday_base import HolidayBase
@@ -32,6 +33,7 @@ class Egypt(HolidayBase, ChristianHolidays, IslamicHolidays, InternationalHolida
     # %s (estimated).
     estimated_label = tr("(تقدير) %s")
     supported_languages = ("ar", "en_US")
+    weekend = {FRI, SAT}
 
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self, JULIAN_CALENDAR)

--- a/holidays/countries/israel.py
+++ b/holidays/countries/israel.py
@@ -13,7 +13,7 @@
 from gettext import gettext as tr
 
 from holidays.calendars import _HebrewLunisolar
-from holidays.calendars.gregorian import _timedelta
+from holidays.calendars.gregorian import _timedelta, FRI, SAT
 from holidays.calendars.hebrew import (
     HANUKKAH,
     INDEPENDENCE_DAY,
@@ -53,6 +53,7 @@ class Israel(ObservedHolidayBase):
     observed_label = tr("(נצפה) %s")
     supported_categories = (OPTIONAL, PUBLIC, SCHOOL)
     supported_languages = ("en_US", "he", "uk")
+    weekend = {FRI, SAT}
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("observed_rule", FRI_TO_PREV_THU + SAT_TO_PREV_THU)

--- a/holidays/countries/jordan.py
+++ b/holidays/countries/jordan.py
@@ -12,6 +12,7 @@
 
 from gettext import gettext as tr
 
+from holidays.calendars.gregorian import THU, FRI, SAT
 from holidays.groups import ChristianHolidays, InternationalHolidays, IslamicHolidays
 from holidays.holiday_base import HolidayBase
 
@@ -36,6 +37,10 @@ class Jordan(HolidayBase, ChristianHolidays, InternationalHolidays, IslamicHolid
         super().__init__(*args, **kwargs)
 
     def _populate_public_holidays(self):
+        # The resting days are Friday and Saturday since Jan 6, 2000.
+        # https://archive.wfn.org/2000/01/msg00078.html
+        self.weekend = {FRI, SAT} if self._year >= 2000 else {THU, FRI}
+
         # New Year's Day.
         self._add_new_years_day(tr("رأس السنة الميلادية"))
 

--- a/holidays/countries/kuwait.py
+++ b/holidays/countries/kuwait.py
@@ -12,6 +12,7 @@
 
 from gettext import gettext as tr
 
+from holidays.calendars.gregorian import THU, FRI, SAT
 from holidays.groups import InternationalHolidays, IslamicHolidays
 from holidays.holiday_base import HolidayBase
 
@@ -36,6 +37,10 @@ class Kuwait(HolidayBase, InternationalHolidays, IslamicHolidays):
         super().__init__(*args, **kwargs)
 
     def _populate_public_holidays(self):
+        # The resting days are Friday and Saturday since Sep 1, 2007.
+        # https://www.arabnews.com/node/298933
+        self.weekend = {FRI, SAT} if self._year >= 2007 else {THU, FRI}
+
         # New Year's Day.
         self._add_new_years_day(tr("رأس السنة الميلادية"))
 


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

This PR implements special weekend format for the following countries:

- Algeria 🇩🇿
     - Pre-1967 : `SAT, SUN`
     - 1976-2008 : `THU, FRI`
     - 2009-Present : `FRI, SAT`
- Bangladesh 🇧🇩 : `FRI, SAT` 
- Brunei 🇧🇳 : `FRI, SUN`
- Egypt 🇪🇬 : `FRI, SAT`
- Israel 🇮🇱 : `FRI, SAT`
- Jordan 🇯🇴 :
     - Pre-2000 : `THU, FRI`
     - 2000-Present : `FRI, SAT`
- Kuwait 🇰🇼 :
     - Pre-2007 : `THU, FRI`
     - 2007-Present : `FRI, SAT`

Resolves #1917.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
