### PR TITLE
Fix misleading France subdivision

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -427,7 +427,7 @@ All other default values are highlighted with bold:
      - UNOFFICIAL
    * - France
      - FR
-     - Départements: BL, GES, GP, GY, MF, MQ, NC, PF, RE, WF, YT
+     - DOM/TOM: BL, GES, GP, GY, MF, MQ, NC, PF, RE, WF, YT
      - en_US, **fr**, uk
      -
    * - Gabon


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change
The France subdivision is misleading as those are **not** department (as in, sub-area in France mainland) but DOM (département d'outre-mer) or TOM (territoire d'outre-mer):  territories outside of France mainland, more or less administratively connected to France.

I don't know if that matters here, but selecting one should be considered optional as most people would live in France mainland, which is none of those choices.

See https://forum.hacf.fr/t/installer-lintegration-vacances/42799/7
## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [X] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I've run `make pre-commit`, it didn't generate any changes
- [ ] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
