### PR TITLE
Update `numpy` test requirements

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -3,8 +3,8 @@
 coverage==7.6.1
 importlib-metadata==8.2.0
 numpy<2.0.0; python_version < '3.9'
-numpy==2.0.*; python_version == '3.9'
-numpy==2.1.*; python_version >= '3.10'
+numpy==2.0.1; python_version == '3.9'
+numpy==2.1.0; python_version > '3.9'
 polib==1.2.0
 pytest-cov==5.0.0
 pytest-xdist==3.6.1

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -3,7 +3,8 @@
 coverage==7.6.1
 importlib-metadata==8.2.0
 numpy<2.0.0; python_version < '3.9'
-numpy==2.0.1; python_version >= '3.9'
+numpy==2.0.*; python_version == '3.9'
+numpy==2.1.*; python_version >= '3.10'
 polib==1.2.0
 pytest-cov==5.0.0
 pytest-xdist==3.6.1


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

`numpy v2.1` drops support for Python 3.9; thus, the test requirements need to be updated accordingly.

Resolves #1941 .

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [x] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
