### PR TITLE
Migrate deprecated United Kingdom subdivisions to subdivision aliases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -877,7 +877,7 @@ All other default values are highlighted with bold:
      -
    * - United Kingdom
      - GB
-     - Subdivisions: ENG, NIR, SCT, WLS
+     - Subdivisions: ENG (England), NIR (Northern Ireland), SCT (Scotland), WLS (Wales)
      -
      -
    * - United States Minor Outlying Islands

--- a/holidays/countries/isle_of_man.py
+++ b/holidays/countries/isle_of_man.py
@@ -20,6 +20,7 @@ class IsleOfMan(UnitedKingdom):
 
     country = "IM"
     subdivisions = ()  # Override UnitedKingdom subdivisions.
+    subdivisions_aliases = {}  # Override UnitedKingdom subdivisions aliases.
 
     def __init__(self, *args, **kwargs):  # Override UnitedKingdom __init__().
         ChristianHolidays.__init__(self)

--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -44,14 +44,13 @@ class UnitedKingdom(ObservedHolidayBase, ChristianHolidays, InternationalHoliday
         "SCT",  # Scotland
         "WLS",  # Wales
     )
-
-    _deprecated_subdivisions: Tuple[str, ...] = (
-        "England",
-        "Northern Ireland",
-        "Scotland",
-        "UK",
-        "Wales",
-    )
+    subdivisions_aliases = {
+        "England": "ENG",
+        "Northern Ireland": "NIR",
+        "Scotland": "SCT",
+        "Wales": "WLS",
+    }
+    _deprecated_subdivisions = ("UK",)
 
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self)
@@ -91,21 +90,12 @@ class UnitedKingdom(ObservedHolidayBase, ChristianHolidays, InternationalHoliday
             else:
                 self._add_holiday_last_mon_of_may(name)
 
-        if self.subdiv == "England":
-            self._populate_subdiv_eng_public_holidays()
-        elif self.subdiv == "Northern Ireland":
-            self._populate_subdiv_nir_public_holidays()
-        elif self.subdiv == "Scotland":
-            self._populate_subdiv_sct_public_holidays()
-        elif self.subdiv == "Wales":
-            self._populate_subdiv_wls_public_holidays()
-
     def _populate_subdiv_holidays(self):
         # Bank Holidays Act 1871
         if self._year <= 1871:
             return None
 
-        if self.subdiv not in {"SCT", "Scotland"}:
+        if self.subdiv != "SCT":
             # New Year's Day
             if self._year >= 1975:
                 self._add_observed(self._add_new_years_day("New Year's Day"))

--- a/tests/countries/test_united_kingdom.py
+++ b/tests/countries/test_united_kingdom.py
@@ -25,7 +25,7 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
         )
         cls.subdiv_holidays = {
             subdiv: UnitedKingdom(subdiv=subdiv, years=(range(1950, 2050)))
-            for subdiv in set(UnitedKingdom.subdivisions)
+            for subdiv in UnitedKingdom.subdivisions
         }
 
     def setUp(self):
@@ -103,25 +103,25 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "2022-01-04",
             "2023-01-03",
         )
-
-        for subdiv in ("SCT",):
-            holidays = self.subdiv_holidays[subdiv]
-            self.assertHolidayName(
-                name_new_year, holidays, (f"{year}-01-01" for year in range(1950, 2050))
-            )
-            self.assertHolidayName(f"{name_new_year} (observed)", holidays, ny_obs_dt)
-            self.assertHolidayName(
-                name_new_year_holiday, holidays, (f"{year}-01-02" for year in range(1950, 2050))
-            )
-            self.assertHolidayName(f"{name_new_year_holiday} (observed)", holidays, nyh_obs_dt)
-            self.assertNoNonObservedHoliday(
-                UnitedKingdom(subdiv=subdiv, observed=False), nyh_obs_dt
-            )
-
-        for subdiv in ("ENG", "NIR", "WLS"):
-            self.assertNoHolidayName(
-                name_new_year_holiday, self.subdiv_holidays[subdiv], range(1950, 2050)
-            )
+        for subdiv, holidays in self.subdiv_holidays.items():
+            if subdiv == "SCT":
+                self.assertHolidayName(
+                    name_new_year, holidays, (f"{year}-01-01" for year in range(1950, 2050))
+                )
+                self.assertHolidayName(f"{name_new_year} (observed)", holidays, ny_obs_dt)
+                self.assertHolidayName(
+                    name_new_year_holiday,
+                    holidays,
+                    (f"{year}-01-02" for year in range(1950, 2050)),
+                )
+                self.assertHolidayName(f"{name_new_year_holiday} (observed)", holidays, nyh_obs_dt)
+                self.assertNoNonObservedHoliday(
+                    UnitedKingdom(subdiv=subdiv, observed=False), nyh_obs_dt
+                )
+            else:
+                self.assertNoHolidayName(
+                    name_new_year_holiday, self.subdiv_holidays[subdiv], range(1950, 2050)
+                )
 
     def test_st_patricks_day(self):
         name = "St. Patrick's Day"
@@ -134,19 +134,20 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "2018-03-19",
             "2019-03-18",
         )
-        for subdiv in ("NIR",):
-            self.assertHolidayName(
-                name, self.subdiv_holidays[subdiv], (f"{year}-03-17" for year in range(1950, 2050))
-            )
-            self.assertHolidayName(f"{name} (observed)", self.subdiv_holidays[subdiv], obs_dt)
-            self.assertNoNonObservedHoliday(UnitedKingdom(subdiv=subdiv, observed=False), obs_dt)
-            self.assertNoHolidayName(name, UnitedKingdom(subdiv=subdiv, years=1902))
+        for subdiv, holidays in self.subdiv_holidays.items():
+            if subdiv == "NIR":
+                self.assertHolidayName(
+                    name, holidays, (f"{year}-03-17" for year in range(1950, 2050))
+                )
+                self.assertHolidayName(f"{name} (observed)", holidays, obs_dt)
+                self.assertNoNonObservedHoliday(
+                    UnitedKingdom(subdiv=subdiv, observed=False), obs_dt
+                )
+                self.assertNoHolidayName(name, UnitedKingdom(subdiv=subdiv, years=1902))
+            else:
+                self.assertNoHoliday(holidays, (f"{year}-03-17" for year in range(1950, 2050)))
+                self.assertNoHolidayName(name, holidays, range(1950, 2050))
 
-        for subdiv in ("ENG", "SCT", "WLS"):
-            self.assertNoHoliday(
-                self.subdiv_holidays[subdiv], (f"{year}-03-17" for year in range(1950, 2050))
-            )
-            self.assertNoHolidayName(name, self.subdiv_holidays[subdiv], range(1950, 2050))
         self.assertNoHoliday(f"{year}-03-17" for year in range(1950, 2050))
         self.assertNoHolidayName(name, range(1950, 2050))
 
@@ -169,12 +170,12 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "2022-04-18",
             "2023-04-10",
         )
-        for subdiv in ("ENG", "NIR", "WLS"):
-            self.assertHolidayName(name, self.subdiv_holidays[subdiv], dt)
-
-        for subdiv in ("SCT",):
-            self.assertNoHoliday(self.subdiv_holidays[subdiv], dt)
-            self.assertNoHolidayName(name, self.subdiv_holidays[subdiv], range(1950, 2050))
+        for subdiv, holidays in self.subdiv_holidays.items():
+            if subdiv == "SCT":
+                self.assertNoHoliday(holidays, dt)
+                self.assertNoHolidayName(name, holidays, range(1950, 2050))
+            else:
+                self.assertHolidayName(name, holidays, dt)
 
         self.assertNoHoliday(dt)
         self.assertNoHolidayName(name, range(1950, 2050))
@@ -222,12 +223,12 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "1969-05-26",
             "1970-05-18",
         )
-        for subdiv in ("ENG", "NIR", "WLS"):
-            self.assertHolidayName(name, self.subdiv_holidays[subdiv], dt)
-
-        for subdiv in ("SCT",):
-            self.assertNoHoliday(self.subdiv_holidays[subdiv], dt)
-            self.assertNoHolidayName(name, self.subdiv_holidays[subdiv], range(1950, 2050))
+        for subdiv, holidays in self.subdiv_holidays.items():
+            if subdiv == "SCT":
+                self.assertNoHoliday(holidays, dt)
+                self.assertNoHolidayName(name, holidays, range(1950, 2050))
+            else:
+                self.assertHolidayName(name, holidays, dt)
 
     def test_spring_bank_holiday(self):
         name = "Spring Bank Holiday"
@@ -258,18 +259,19 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "2015-07-13",
             "2020-07-13",
         )
-        for subdiv in ("NIR",):
-            self.assertHolidayName(
-                name, self.subdiv_holidays[subdiv], (f"{year}-07-12" for year in range(1950, 2050))
-            )
-            self.assertHolidayName(f"{name} (observed)", self.subdiv_holidays[subdiv], obs_dt)
-            self.assertNoNonObservedHoliday(UnitedKingdom(subdiv=subdiv, observed=False), obs_dt)
+        for subdiv, holidays in self.subdiv_holidays.items():
+            if subdiv == "NIR":
+                self.assertHolidayName(
+                    name, holidays, (f"{year}-07-12" for year in range(1950, 2050))
+                )
+                self.assertHolidayName(f"{name} (observed)", holidays, obs_dt)
+                self.assertNoNonObservedHoliday(
+                    UnitedKingdom(subdiv=subdiv, observed=False), obs_dt
+                )
+            else:
+                self.assertNoHoliday(holidays, (f"{year}-07-12" for year in range(1950, 2050)))
+                self.assertNoHolidayName(name, holidays, range(1950, 2050))
 
-        for subdiv in ("ENG", "SCT", "WLS"):
-            self.assertNoHoliday(
-                self.subdiv_holidays[subdiv], (f"{year}-07-12" for year in range(1950, 2050))
-            )
-            self.assertNoHolidayName(name, self.subdiv_holidays[subdiv], range(1950, 2050))
         self.assertNoHoliday(f"{year}-07-12" for year in range(1950, 2050))
         self.assertNoHolidayName(name, range(1950, 2050))
 
@@ -289,12 +291,12 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "2022-08-01",
             "2023-08-07",
         )
-        for subdiv in ("SCT",):
-            self.assertHolidayName(name, self.subdiv_holidays[subdiv], dt)
-
-        for subdiv in ("ENG", "NIR", "WLS"):
-            self.assertNoHoliday(self.subdiv_holidays[subdiv], dt)
-            self.assertNoHolidayName(name, self.subdiv_holidays[subdiv], range(1950, 2050))
+        for subdiv, holidays in self.subdiv_holidays.items():
+            if subdiv == "SCT":
+                self.assertHolidayName(name, holidays, dt)
+            else:
+                self.assertNoHoliday(holidays, dt)
+                self.assertNoHolidayName(name, holidays, range(1950, 2050))
 
         self.assertNoHoliday(dt)
         self.assertNoHolidayName(name, range(1950, 2050))
@@ -315,15 +317,14 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "2022-08-29",
             "2023-08-28",
         )
-
-        for subdiv in ("ENG", "NIR", "WLS"):
-            self.assertHolidayName(name, self.subdiv_holidays[subdiv], dt)
-            self.assertHolidayName(name, self.subdiv_holidays[subdiv], range(1971, 2050))
-            self.assertNoHolidayName(name, self.subdiv_holidays[subdiv], range(1950, 1971))
-
-        for subdiv in ("SCT",):
-            self.assertNoHoliday(self.subdiv_holidays[subdiv], dt)
-            self.assertNoHolidayName(name, self.subdiv_holidays[subdiv], range(1950, 2050))
+        for subdiv, holidays in self.subdiv_holidays.items():
+            if subdiv == "SCT":
+                self.assertNoHoliday(holidays, dt)
+                self.assertNoHolidayName(name, holidays, range(1950, 2050))
+            else:
+                self.assertHolidayName(name, holidays, dt)
+                self.assertHolidayName(name, holidays, range(1971, 2050))
+                self.assertNoHolidayName(name, holidays, range(1950, 1971))
 
         self.assertNoHoliday(dt)
         self.assertNoHolidayName(name, range(1950, 2050))
@@ -336,22 +337,21 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "2014-12-01",
             "2019-12-02",
         )
-        for subdiv in ("SCT",):
-            self.assertHolidayName(
-                name, self.subdiv_holidays[subdiv], (f"{year}-11-30" for year in range(2006, 2050))
-            )
-            self.assertNoHoliday(
-                self.subdiv_holidays[subdiv], (f"{year}-11-30" for year in range(1950, 2006))
-            )
-            self.assertNoHolidayName(name, self.subdiv_holidays[subdiv], range(1950, 2006))
-            self.assertHolidayName(f"{name} (observed)", self.subdiv_holidays[subdiv], obs_dt)
-            self.assertNoNonObservedHoliday(UnitedKingdom(subdiv=subdiv, observed=False), obs_dt)
+        for subdiv, holidays in self.subdiv_holidays.items():
+            if subdiv == "SCT":
+                self.assertHolidayName(
+                    name, holidays, (f"{year}-11-30" for year in range(2006, 2050))
+                )
+                self.assertNoHoliday(holidays, (f"{year}-11-30" for year in range(1950, 2006)))
+                self.assertNoHolidayName(name, holidays, range(1950, 2006))
+                self.assertHolidayName(f"{name} (observed)", holidays, obs_dt)
+                self.assertNoNonObservedHoliday(
+                    UnitedKingdom(subdiv=subdiv, observed=False), obs_dt
+                )
+            else:
+                self.assertNoHoliday(holidays, (f"{year}-11-30" for year in range(1950, 2050)))
+                self.assertNoHolidayName(name, holidays, range(1950, 2050))
 
-        for subdiv in ("ENG", "NIR", "WLS"):
-            self.assertNoHoliday(
-                self.subdiv_holidays[subdiv], (f"{year}-11-30" for year in range(1950, 2050))
-            )
-            self.assertNoHolidayName(name, self.subdiv_holidays[subdiv], range(1950, 2050))
         self.assertNoHoliday(f"{year}-11-30" for year in range(1950, 2050))
         self.assertNoHolidayName(name, range(1950, 2050))
 

--- a/tests/countries/test_united_kingdom.py
+++ b/tests/countries/test_united_kingdom.py
@@ -23,13 +23,9 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
         super().setUpClass(
             UnitedKingdom, years=range(1950, 2050), years_non_observed=range(2000, 2024)
         )
-
-        warnings.simplefilter("ignore", category=DeprecationWarning)
         cls.subdiv_holidays = {
             subdiv: UnitedKingdom(subdiv=subdiv, years=(range(1950, 2050)))
-            for subdiv in set(UnitedKingdom.subdivisions).union(
-                set(UnitedKingdom._deprecated_subdivisions)
-            )
+            for subdiv in set(UnitedKingdom.subdivisions)
         }
 
     def setUp(self):
@@ -39,6 +35,9 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
     def test_country_aliases(self):
         self.assertAliases(UnitedKingdom, UK, GBR)
         self.assertAliases(UnitedKingdom, GB, GBR)
+
+    def test_subdiv_deprecation(self):
+        self.assertDeprecatedSubdivisions("This subdivision is deprecated and will be removed")
 
     def test_no_holidays(self):
         self.assertNoHolidays(UnitedKingdom(years=1870))
@@ -105,7 +104,7 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "2023-01-03",
         )
 
-        for subdiv in ("SCT", "Scotland"):
+        for subdiv in ("SCT",):
             holidays = self.subdiv_holidays[subdiv]
             self.assertHolidayName(
                 name_new_year, holidays, (f"{year}-01-01" for year in range(1950, 2050))
@@ -119,14 +118,7 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
                 UnitedKingdom(subdiv=subdiv, observed=False), nyh_obs_dt
             )
 
-        for subdiv in (
-            "ENG",
-            "NIR",
-            "WLS",
-            "England",
-            "Northern Ireland",
-            "Wales",
-        ):
+        for subdiv in ("ENG", "NIR", "WLS"):
             self.assertNoHolidayName(
                 name_new_year_holiday, self.subdiv_holidays[subdiv], range(1950, 2050)
             )
@@ -142,7 +134,7 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "2018-03-19",
             "2019-03-18",
         )
-        for subdiv in ("NIR", "Northern Ireland"):
+        for subdiv in ("NIR",):
             self.assertHolidayName(
                 name, self.subdiv_holidays[subdiv], (f"{year}-03-17" for year in range(1950, 2050))
             )
@@ -150,7 +142,7 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             self.assertNoNonObservedHoliday(UnitedKingdom(subdiv=subdiv, observed=False), obs_dt)
             self.assertNoHolidayName(name, UnitedKingdom(subdiv=subdiv, years=1902))
 
-        for subdiv in ("ENG", "SCT", "WLS", "England", "Scotland", "Wales"):
+        for subdiv in ("ENG", "SCT", "WLS"):
             self.assertNoHoliday(
                 self.subdiv_holidays[subdiv], (f"{year}-03-17" for year in range(1950, 2050))
             )
@@ -177,17 +169,10 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "2022-04-18",
             "2023-04-10",
         )
-        for subdiv in (
-            "ENG",
-            "NIR",
-            "WLS",
-            "England",
-            "Northern Ireland",
-            "Wales",
-        ):
+        for subdiv in ("ENG", "NIR", "WLS"):
             self.assertHolidayName(name, self.subdiv_holidays[subdiv], dt)
 
-        for subdiv in ("SCT", "Scotland"):
+        for subdiv in ("SCT",):
             self.assertNoHoliday(self.subdiv_holidays[subdiv], dt)
             self.assertNoHolidayName(name, self.subdiv_holidays[subdiv], range(1950, 2050))
 
@@ -237,17 +222,10 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "1969-05-26",
             "1970-05-18",
         )
-        for subdiv in (
-            "ENG",
-            "NIR",
-            "WLS",
-            "England",
-            "Northern Ireland",
-            "Wales",
-        ):
+        for subdiv in ("ENG", "NIR", "WLS"):
             self.assertHolidayName(name, self.subdiv_holidays[subdiv], dt)
 
-        for subdiv in ("SCT", "Scotland"):
+        for subdiv in ("SCT",):
             self.assertNoHoliday(self.subdiv_holidays[subdiv], dt)
             self.assertNoHolidayName(name, self.subdiv_holidays[subdiv], range(1950, 2050))
 
@@ -280,14 +258,14 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "2015-07-13",
             "2020-07-13",
         )
-        for subdiv in ("NIR", "Northern Ireland"):
+        for subdiv in ("NIR",):
             self.assertHolidayName(
                 name, self.subdiv_holidays[subdiv], (f"{year}-07-12" for year in range(1950, 2050))
             )
             self.assertHolidayName(f"{name} (observed)", self.subdiv_holidays[subdiv], obs_dt)
             self.assertNoNonObservedHoliday(UnitedKingdom(subdiv=subdiv, observed=False), obs_dt)
 
-        for subdiv in ("ENG", "SCT", "WLS", "England", "Scotland", "Wales"):
+        for subdiv in ("ENG", "SCT", "WLS"):
             self.assertNoHoliday(
                 self.subdiv_holidays[subdiv], (f"{year}-07-12" for year in range(1950, 2050))
             )
@@ -311,17 +289,10 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "2022-08-01",
             "2023-08-07",
         )
-        for subdiv in ("SCT", "Scotland"):
+        for subdiv in ("SCT",):
             self.assertHolidayName(name, self.subdiv_holidays[subdiv], dt)
 
-        for subdiv in (
-            "ENG",
-            "NIR",
-            "WLS",
-            "England",
-            "Northern Ireland",
-            "Wales",
-        ):
+        for subdiv in ("ENG", "NIR", "WLS"):
             self.assertNoHoliday(self.subdiv_holidays[subdiv], dt)
             self.assertNoHolidayName(name, self.subdiv_holidays[subdiv], range(1950, 2050))
 
@@ -345,19 +316,12 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "2023-08-28",
         )
 
-        for subdiv in (
-            "ENG",
-            "NIR",
-            "WLS",
-            "England",
-            "Northern Ireland",
-            "Wales",
-        ):
+        for subdiv in ("ENG", "NIR", "WLS"):
             self.assertHolidayName(name, self.subdiv_holidays[subdiv], dt)
             self.assertHolidayName(name, self.subdiv_holidays[subdiv], range(1971, 2050))
             self.assertNoHolidayName(name, self.subdiv_holidays[subdiv], range(1950, 1971))
 
-        for subdiv in ("SCT", "Scotland"):
+        for subdiv in ("SCT",):
             self.assertNoHoliday(self.subdiv_holidays[subdiv], dt)
             self.assertNoHolidayName(name, self.subdiv_holidays[subdiv], range(1950, 2050))
 
@@ -372,7 +336,7 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "2014-12-01",
             "2019-12-02",
         )
-        for subdiv in ("SCT", "Scotland"):
+        for subdiv in ("SCT",):
             self.assertHolidayName(
                 name, self.subdiv_holidays[subdiv], (f"{year}-11-30" for year in range(2006, 2050))
             )
@@ -383,14 +347,7 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             self.assertHolidayName(f"{name} (observed)", self.subdiv_holidays[subdiv], obs_dt)
             self.assertNoNonObservedHoliday(UnitedKingdom(subdiv=subdiv, observed=False), obs_dt)
 
-        for subdiv in (
-            "ENG",
-            "NIR",
-            "WLS",
-            "England",
-            "Northern Ireland",
-            "Wales",
-        ):
+        for subdiv in ("ENG", "NIR", "WLS"):
             self.assertNoHoliday(
                 self.subdiv_holidays[subdiv], (f"{year}-11-30" for year in range(1950, 2050))
             )
@@ -465,6 +422,3 @@ class TestUnitedKingdom(CommonCountryTests, TestCase):
             "Boxing Day",
         }
         self.assertEqual(all_holidays, y_2015)
-
-    def test_subdiv_deprecation(self):
-        self.assertDeprecatedSubdivisions("This subdivision is deprecated and will be removed")


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

This PR migrates the United Kingdom's deprecated subdivisions to the new subdivision aliases system.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
