### PR TITLE
Restore Malaysia's 3-letter code as subdivisions aliases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -612,7 +612,7 @@ All other default values are highlighted with bold:
      -
    * - Malaysia
      - MY
-     - States and federal territories: 01 (Johor), 02 (Kedah), 03 (Kelantan), 04 (Melaka), 05 (Negeri Sembilan), 06 (Pahang), 07 (Pulau Pinang), 08 (Perak), 09 (Perlis), 10 (Selangor), 11 (Terengganu), 12 (Sabah), 13 (Sarawak), 14 (WP Kuala Lumpur), 15 (WP Labuan), 16 (WP Putrajaya)
+     - States and federal territories: 01 (Johor, JHR), 02 (Kedah, KDH), 03 (Kelantan, KTN), 04 (Melaka, MLK), 05 (Negeri Sembilan, NSN), 06 (Pahang, PHG), 07 (Pulau Pinang, PNG), 08 (Perak, PRK), 09 (Perlis, PLS), 10 (Selangor, SGR), 11 (Terengganu, TRG), 12 (Sabah, SBH), 13 (Sarawak, SWK), 14 (WP Kuala Lumpur, KUL), 15 (WP Labuan, LBN), 16 (WP Putrajaya, PJY)
      - en_US, **ms_MY**
      -
    * - Maldives

--- a/holidays/countries/malaysia.py
+++ b/holidays/countries/malaysia.py
@@ -87,41 +87,39 @@ class Malaysia(
         "15",
         "16",
     )
-    _deprecated_subdivisions = (
-        "JHR",
-        "KDH",
-        "KTN",
-        "KUL",
-        "LBN",
-        "MLK",
-        "NSN",
-        "PHG",
-        "PJY",
-        "PLS",
-        "PNG",
-        "PRK",
-        "SBH",
-        "SGR",
-        "SWK",
-        "TRG",
-    )
     subdivisions_aliases = {
         "Johor": "01",
+        "JHR": "01",
         "Kedah": "02",
+        "KDH": "02",
         "Kelantan": "03",
+        "KTN": "03",
         "Melaka": "04",
+        "MLK": "04",
         "Negeri Sembilan": "05",
+        "NSN": "05",
         "Pahang": "06",
+        "PHG": "06",
         "Pulau Pinang": "07",
+        "PNG": "07",
         "Perak": "08",
+        "PRK": "08",
         "Perlis": "09",
+        "PLS": "09",
         "Selangor": "10",
+        "SGR": "10",
         "Terengganu": "11",
+        "TRG": "11",
         "Sabah": "12",
+        "SBH": "12",
         "Sarawak": "13",
+        "SWK": "13",
         "WP Kuala Lumpur": "14",
+        "KUL": "14",
         "WP Labuan": "15",
+        "LBN": "15",
         "WP Putrajaya": "16",
+        "PJY": "16",
     }
     supported_languages = ("en_US", "ms_MY")
 
@@ -215,26 +213,6 @@ class Malaysia(
     def _populate_subdiv_holidays(self):
         if self._year <= 1951:
             return None
-
-        deprecated_mapping = {
-            "JHR": "01",
-            "KDH": "02",
-            "KTN": "03",
-            "KUL": "14",
-            "LBN": "15",
-            "MLK": "04",
-            "NSN": "05",
-            "PHG": "06",
-            "PJY": "16",
-            "PLS": "09",
-            "PNG": "07",
-            "PRK": "08",
-            "SBH": "12",
-            "SGR": "10",
-            "SWK": "13",
-            "TRG": "11",
-        }
-        self.subdiv = deprecated_mapping.get(self.subdiv, self.subdiv)
 
         if self.subdiv and self.subdiv not in {"13", "15"}:
             # Deepavali.

--- a/tests/countries/test_malaysia.py
+++ b/tests/countries/test_malaysia.py
@@ -10,7 +10,6 @@
 #  Website: https://github.com/vacanza/python-holidays
 #  License: MIT (see LICENSE file)
 
-import warnings
 from unittest import TestCase
 
 from holidays.countries.malaysia import Malaysia, MY, MYS

--- a/tests/countries/test_malaysia.py
+++ b/tests/countries/test_malaysia.py
@@ -33,33 +33,6 @@ class TestMalaysia(CommonCountryTests, TestCase):
     def test_country_aliases(self):
         self.assertAliases(Malaysia, MY, MYS)
 
-    def test_subdiv_deprecation(self):
-        self.assertDeprecatedSubdivisions("This subdivision is deprecated and will be removed")
-
-    def test_deprecated(self):
-        for subdiv1, subdiv2 in (
-            ("JHR", "01"),
-            ("KDH", "02"),
-            ("KTN", "03"),
-            ("KUL", "14"),
-            ("LBN", "15"),
-            ("MLK", "04"),
-            ("NSN", "05"),
-            ("PHG", "06"),
-            ("PJY", "16"),
-            ("PLS", "09"),
-            ("PNG", "07"),
-            ("PRK", "08"),
-            ("SBH", "12"),
-            ("SGR", "10"),
-            ("SWK", "13"),
-            ("TRG", "11"),
-        ):
-            self.assertEqual(
-                sorted(Malaysia(subdiv=subdiv1, years=2023).keys()),
-                sorted(Malaysia(subdiv=subdiv2, years=2023).keys()),
-            )
-
     def test_no_holidays(self):
         self.assertNoHolidays(Malaysia(years=1951))
 

--- a/tests/countries/test_malaysia.py
+++ b/tests/countries/test_malaysia.py
@@ -26,10 +26,6 @@ class TestMalaysia(CommonCountryTests, TestCase):
             for subdiv in Malaysia.subdivisions
         }
 
-    def setUp(self):
-        super().setUp()
-        warnings.simplefilter("ignore", category=DeprecationWarning)
-
     def test_country_aliases(self):
         self.assertAliases(Malaysia, MY, MYS)
 


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Restores Malaysia's 3-letter code (previously list as deprecated) as alternative subdivision aliases, as done for Austria's implementation in  #1662 .

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
