### PR TITLE
Migrate deprecated Bosnia-Herzegovina subdivisions to subdivision aliases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -277,7 +277,7 @@ All other default values are highlighted with bold:
      -
    * - Bosnia and Herzegovina
      - BA
-     - Entities and district: BIH, BRC, SRP
+     - Entities and district: BIH (Federacija Bosne i Hercegovine, FBiH), BRC (Brčko distrikt, BD), SRP (Republika Srpska, RS)
      - **bs**, en_US, sr, uk
      -
    * - Botswana

--- a/holidays/countries/bosnia_and_herzegovina.py
+++ b/holidays/countries/bosnia_and_herzegovina.py
@@ -64,11 +64,14 @@ class BosniaAndHerzegovina(
         "BRC",  # Brčko distrikt
         "SRP",  # Republika Srpska
     )
-    _deprecated_subdivisions = (
-        "BD",
-        "FBiH",
-        "RS",
-    )
+    subdivisions_aliases = {
+        "Federacija Bosne i Hercegovine": "BIH",
+        "FBiH": "BIH",
+        "Brčko distrikt": "BRC",
+        "BD": "BRC",
+        "Republika Srpska": "SRP",
+        "RS": "SRP",
+    }
 
     def __init__(self, *args, **kwargs):
         ChristianHolidays.__init__(self, JULIAN_CALENDAR)
@@ -89,13 +92,6 @@ class BosniaAndHerzegovina(
 
         # Eid al-Adha.
         self._add_eid_al_adha_day(tr("Kurban Bajram"))
-
-        if self.subdiv == "BD":
-            self._populate_subdiv_brc_public_holidays()
-        elif self.subdiv == "FBiH":
-            self._populate_subdiv_bih_public_holidays()
-        elif self.subdiv == "RS":
-            self._populate_subdiv_srp_public_holidays()
 
     def _populate_subdiv_holidays(self):
         if not self.subdiv:

--- a/tests/countries/test_bosnia_and_herzegovina.py
+++ b/tests/countries/test_bosnia_and_herzegovina.py
@@ -10,7 +10,6 @@
 #  Website: https://github.com/vacanza/python-holidays
 #  License: MIT (see LICENSE file)
 
-import warnings
 from unittest import TestCase
 
 from holidays.countries.bosnia_and_herzegovina import BosniaAndHerzegovina, BA, BIH
@@ -28,10 +27,6 @@ class TestBosniaAndHerzegovina(CommonCountryTests, TestCase):
         cls.bih_holidays_non_obs = BosniaAndHerzegovina(subdiv="BIH", observed=False, years=years)
         cls.brc_holidays_non_obs = BosniaAndHerzegovina(subdiv="BRC", observed=False, years=years)
         cls.srp_holidays_non_obs = BosniaAndHerzegovina(subdiv="SRP", observed=False, years=years)
-
-    def setUp(self):
-        super().setUp()
-        warnings.simplefilter("ignore", category=DeprecationWarning)
 
     def test_country_aliases(self):
         self.assertAliases(BosniaAndHerzegovina, BA, BIH)
@@ -377,20 +372,6 @@ class TestBosniaAndHerzegovina(CommonCountryTests, TestCase):
         )
         self.assertNoHolidayName(name, self.brc_holidays)
         self.assertNoHolidayName(name)
-
-    def test_deprecated(self):
-        for subdiv1, subdiv2 in (
-            ("BD", "BRC"),
-            ("FBiH", "BIH"),
-            ("RS", "SRP"),
-        ):
-            self.assertEqual(
-                BosniaAndHerzegovina(subdiv=subdiv1, years=2022).keys(),
-                BosniaAndHerzegovina(subdiv=subdiv2, years=2022).keys(),
-            )
-
-    def test_subdiv_deprecation(self):
-        self.assertDeprecatedSubdivisions("This subdivision is deprecated and will be removed")
 
     def test_2021(self):
         self.assertHolidays(


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

This PR migrates the Bosnia-Herzegovina's deprecated subdivisions to the new subdivision aliases system.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
