### PR TITLE
Update HU: add 2025 substituted holidays

### DIFF
--- a/holidays/countries/hungary.py
+++ b/holidays/countries/hungary.py
@@ -39,6 +39,7 @@ class Hungary(HolidayBase, ChristianHolidays, InternationalHolidays, StaticHolid
       - `2021 <https://njt.hu/jogszabaly/2020-14-20-7Q>`_
       - `2022 <https://njt.hu/jogszabaly/2021-23-20-7Q>`_
       - `2024 <https://njt.hu/jogszabaly/2023-15-20-8P>`_
+      - `2025 <https://njt.hu/jogszabaly/2024-11-20-2X>`_
     """
 
     country = "HU"
@@ -192,5 +193,10 @@ class HungaryStaticHolidays:
             (AUG, 19, AUG, 3),
             (DEC, 24, DEC, 7),
             (DEC, 27, DEC, 14),
+        ),
+        2025: (
+            (MAY, 2, MAY, 17),
+            (OCT, 24, OCT, 18),
+            (DEC, 24, DEC, 13),
         ),
     }

--- a/tests/countries/test_hungary.py
+++ b/tests/countries/test_hungary.py
@@ -221,6 +221,9 @@ class TestHungary(CommonCountryTests, TestCase):
             "2024-08-19",
             "2024-12-24",
             "2024-12-27",
+            "2025-05-02",
+            "2025-10-24",
+            "2025-12-24",
         )
         self.assertHoliday(dt)
 


### PR DESCRIPTION
Added 2025 Substituted holidays for Hungary according to the NGM ministry.

<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Added 2025 Substituted holidays for Hungary according to the NGM ministry.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [ ] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I've run `make pre-commit`, it didn't generate any changes
- [ ] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
