### PR TITLE
Add Frances Xavier Cabrini Day for United States, Colorado

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,8 @@ repos:
     rev: 1.7.9
     hooks:
       - id: bandit
+        additional_dependencies:
+          - .[toml]
         args:
           - --configfile=pyproject.toml
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     hooks:
       - id: bandit
         additional_dependencies:
-          - .[toml]
+          - bandit[toml]
         args:
           - --configfile=pyproject.toml
 

--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -40,6 +40,9 @@ class UnitedStates(ObservedHolidayBase, ChristianHolidays, InternationalHolidays
     - https://en.wikipedia.org/wiki/Indigenous_Peoples%27_Day_(United_States)
     - https://www.sos.ri.gov/divisions/civics-and-education/reference-desk/ri-state-holidays
     - https://web.archive.org/web/20080831103521/http://www.dpa.ca.gov/personnel-policies/holidays.htm
+
+    Frances Xavier Cabrini Day:
+        - https://leg.colorado.gov/sites/default/files/2020a_1031_signed.pdf
     """
 
     country = "US"
@@ -324,9 +327,9 @@ class UnitedStates(ObservedHolidayBase, ChristianHolidays, InternationalHolidays
         # Cesar Chavez Day
         if self._year >= 2001:
             self._add_holiday_mar_31("Cesar Chavez Day")
+
+        # Frances Xavier Cabrini Day
         if self._year >= 2020:
-            # Frances Xavier Cabrini Day
-            # https://leg.colorado.gov/sites/default/files/2020a_1031_signed.pdf
             self._add_holiday_1st_mon_of_oct("Frances Xavier Cabrini Day")
 
     def _populate_subdiv_ct_public_holidays(self):

--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -324,6 +324,10 @@ class UnitedStates(ObservedHolidayBase, ChristianHolidays, InternationalHolidays
         # Cesar Chavez Day
         if self._year >= 2001:
             self._add_holiday_mar_31("Cesar Chavez Day")
+        if self._year >= 2020:
+            # Frances Xavier Cabrini Day
+            # https://leg.colorado.gov/sites/default/files/2020a_1031_signed.pdf
+            self._add_holiday_1st_mon_of_oct("Frances Xavier Cabrini Day")
 
     def _populate_subdiv_ct_public_holidays(self):
         # Lincoln's Birthday

--- a/tests/countries/test_united_states.py
+++ b/tests/countries/test_united_states.py
@@ -1889,15 +1889,18 @@ class TestUS(CommonCountryTests, TestCase):
             )
 
     def test_frances_xavier_cabrini_day(self):
+        co_holidays = self.state_hols["CO"]
         name = "Frances Xavier Cabrini Day"
-        self.assertNoHolidayName(name, self.state_hols["CO"], range(2000, 2019))
-        self.assertHolidayName(name, self.state_hols["CO"], range(2020, 2024))
 
-        dt = (
-            "2020-10-05",
-            "2021-10-04",
-            "2022-10-03",
-            "2023-10-02",
-            "2024-10-07",
+        self.assertNoHolidayName(name, co_holidays, range(2000, 2019))
+        self.assertHolidayName(name, co_holidays, range(2020, 2024))
+        self.assertHoliday(
+            co_holidays,
+            (
+                "2020-10-05",
+                "2021-10-04",
+                "2022-10-03",
+                "2023-10-02",
+                "2024-10-07",
+            ),
         )
-        self.assertHoliday(self.state_hols["CO"], dt)

--- a/tests/countries/test_united_states.py
+++ b/tests/countries/test_united_states.py
@@ -1887,3 +1887,17 @@ class TestUS(CommonCountryTests, TestCase):
             self.assertNoNonObservedHolidayName(
                 f"{name} (observed)", UnitedStates(subdiv=subdiv, observed=False), obs_dt
             )
+
+    def test_frances_xavier_cabrini_day(self):
+        name = "Frances Xavier Cabrini Day"
+        self.assertNoHolidayName(name, self.state_hols["CO"], range(2000, 2019))
+        self.assertHolidayName(name, self.state_hols["CO"], range(2020, 2024))
+
+        dt = (
+            "2020-10-05",
+            "2021-10-04",
+            "2022-10-03",
+            "2023-10-02",
+            "2024-10-07",
+        )
+        self.assertHoliday(self.state_hols["CO"], dt)


### PR DESCRIPTION
## Proposed change

Add the Colorado state holiday Francis Xavier Cabrini Day

## Type of change

- [ ] New country/market holidays support (thank you!)
- [x] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
