### PR TITLE
Bump numpy from 2.0.1 to 2.0.2

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -3,7 +3,7 @@
 coverage==7.6.1
 importlib-metadata==8.4.0
 numpy<2.0.0; python_version < '3.9'
-numpy==2.0.1; python_version == '3.9'
+numpy==2.0.2; python_version == '3.9'
 numpy==2.1.1; python_version > '3.9'
 polib==1.2.0
 pytest-cov==5.0.0


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Actually bumps [numpy](https://github.com/numpy/numpy) from 2.0.1 to 2.0.2 - now at the correct section of the code. I suspect this will likely remain an issue until Python 3.8's deprecation date sometime this October...

Resolves #2003.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [x] Dependency update (version deprecation/pin/upgrade)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/vacanza/python-holidays/blob/dev/CONTRIBUTING.rst
[docs]: https://github.com/vacanza/python-holidays/tree/dev/docs/source
